### PR TITLE
Add Worklog API for agent session drift prevention

### DIFF
--- a/src/app/api/worklog/route.ts
+++ b/src/app/api/worklog/route.ts
@@ -1,0 +1,152 @@
+/**
+ * API route: /api/worklog
+ * Agent session worklog - the drift-prevention system
+ *
+ * GET  - Read recent worklog entries (optional ?limit=N&agent_id=X) - PUBLIC
+ * POST - Write a worklog entry on session end - REQUIRES API KEY
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  create_worklog_entry,
+  get_worklog_entries,
+  WorklogEntry
+} from '@/lib/db';
+
+const ALLOWED_ORIGINS = ['https://8i11.vercel.app', 'http://localhost:3000'];
+
+function cors_headers(origin?: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    'Access-Control-Allow-Origin': allowed,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, X-Worklog-Key',
+  };
+}
+
+function require_worklog_key(request: NextRequest): NextResponse | null {
+  const key = request.headers.get('X-Worklog-Key');
+  const valid_key = process.env.WORKLOG_API_KEY || '';
+
+  if (!valid_key) {
+    return NextResponse.json(
+      { error: 'Worklog API key not configured on server' },
+      { status: 503, headers: cors_headers() }
+    );
+  }
+
+  if (key === valid_key) {
+    return null;
+  }
+
+  return NextResponse.json(
+    { error: 'Authentication required (X-Worklog-Key)' },
+    { status: 401, headers: cors_headers() }
+  );
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return NextResponse.json({}, { headers: cors_headers(request.headers.get('origin')) });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '3', 10) || 3, 50);
+    const agent_id = searchParams.get('agent_id') || undefined;
+
+    const entries = await get_worklog_entries(limit, agent_id);
+
+    return NextResponse.json({
+      success: true,
+      entries,
+      count: entries.length
+    }, { headers: cors_headers(request.headers.get('origin')) });
+  } catch (error) {
+    console.error('GET worklog error:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch worklog entries' },
+      { status: 500, headers: cors_headers() }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  // Proxy to production when running locally
+  if (!process.env.TURSO_DATABASE_URL) {
+    const body = await request.text();
+    const key = request.headers.get('X-Worklog-Key') || '';
+    const res = await fetch('https://8i11.vercel.app/api/worklog', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Worklog-Key': key,
+      },
+      body,
+    });
+    return NextResponse.json(await res.json(), { status: res.status });
+  }
+
+  const auth_error = require_worklog_key(request);
+  if (auth_error) return auth_error;
+
+  try {
+    const body = await request.json();
+
+    const { agent_id, machine_id, session_id, summary, tasks_touched, status, tags } = body;
+
+    // Validate required fields
+    if (!agent_id || typeof agent_id !== 'string') {
+      return NextResponse.json({ error: 'agent_id is required' }, { status: 400, headers: cors_headers() });
+    }
+    if (!machine_id || typeof machine_id !== 'string') {
+      return NextResponse.json({ error: 'machine_id is required' }, { status: 400, headers: cors_headers() });
+    }
+    const uuid_re = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!session_id || typeof session_id !== 'string' || !uuid_re.test(session_id)) {
+      return NextResponse.json({ error: 'session_id is required and must be a UUID' }, { status: 400, headers: cors_headers() });
+    }
+    if (!summary || typeof summary !== 'string' || summary.trim().length === 0) {
+      return NextResponse.json({ error: 'summary is required' }, { status: 400, headers: cors_headers() });
+    }
+    if (summary.length > 10000) {
+      return NextResponse.json({ error: 'summary must be under 10000 characters' }, { status: 413, headers: cors_headers() });
+    }
+
+    // Validate status enum
+    const valid_statuses: WorklogEntry['status'][] = ['info', 'warning', 'blocked', 'done'];
+    const entry_status = status || 'info';
+    if (!valid_statuses.includes(entry_status)) {
+      return NextResponse.json(
+        { error: 'status must be one of: info, warning, blocked, done' },
+        { status: 400, headers: cors_headers() }
+      );
+    }
+
+    // Validate arrays
+    const entry_tasks = Array.isArray(tasks_touched) ? tasks_touched.filter((t: unknown) => typeof t === 'string') : [];
+    const entry_tags = Array.isArray(tags) ? tags.filter((t: unknown) => typeof t === 'string') : [];
+
+    const id = await create_worklog_entry(
+      agent_id.trim(),
+      machine_id.trim(),
+      session_id.trim(),
+      summary.trim(),
+      entry_tasks,
+      entry_status,
+      entry_tags
+    );
+
+    return NextResponse.json({
+      success: true,
+      id,
+      message: 'Worklog entry created'
+    }, { headers: cors_headers(request.headers.get('origin')) });
+  } catch (error) {
+    console.error('POST worklog error:', error);
+    return NextResponse.json(
+      { error: 'Failed to create worklog entry' },
+      { status: 500, headers: cors_headers() }
+    );
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1816,3 +1816,139 @@ export async function is_wellness_cached(date: string): Promise<boolean> {
 
   return result.rows.length > 0;
 }
+
+// ============================================================================
+// Worklog (Agent Session Summaries)
+// ============================================================================
+
+export interface WorklogEntry {
+  id: string;
+  created_at: string;
+  agent_id: string;
+  machine_id: string;
+  session_id: string;
+  summary: string;
+  tasks_touched: string[];
+  status: 'info' | 'warning' | 'blocked' | 'done';
+  tags: string[];
+}
+
+async function init_worklog_schema(): Promise<void> {
+  const db = get_client();
+
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS worklog (
+      id TEXT PRIMARY KEY,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      agent_id TEXT NOT NULL,
+      machine_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      tasks_touched TEXT DEFAULT '[]',
+      status TEXT DEFAULT 'info',
+      tags TEXT DEFAULT '[]'
+    )
+  `);
+
+  await db.execute(`
+    CREATE INDEX IF NOT EXISTS idx_worklog_created_at ON worklog(created_at DESC)
+  `);
+
+  await db.execute(`
+    CREATE INDEX IF NOT EXISTS idx_worklog_agent_id ON worklog(agent_id)
+  `);
+}
+
+let worklog_schema_initialized = false;
+async function ensure_worklog_schema(): Promise<void> {
+  if (!worklog_schema_initialized) {
+    await init_worklog_schema();
+    worklog_schema_initialized = true;
+  }
+}
+
+/**
+ * Create a new worklog entry
+ */
+export async function create_worklog_entry(
+  agent_id: string,
+  machine_id: string,
+  session_id: string,
+  summary: string,
+  tasks_touched: string[],
+  status: WorklogEntry['status'],
+  tags: string[]
+): Promise<string> {
+  await ensure_worklog_schema();
+  const db = get_client();
+
+  const id = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO worklog (id, agent_id, machine_id, session_id, summary, tasks_touched, status, tags)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [id, agent_id, machine_id, session_id, summary, JSON.stringify(tasks_touched), status, JSON.stringify(tags)]
+  });
+
+  return id;
+}
+
+/**
+ * Get recent worklog entries, optionally filtered by agent_id
+ */
+export async function get_worklog_entries(limit: number = 3, agent_id?: string): Promise<WorklogEntry[]> {
+  await ensure_worklog_schema();
+  const db = get_client();
+
+  let sql = 'SELECT * FROM worklog';
+  const args: (string | number)[] = [];
+
+  if (agent_id) {
+    sql += ' WHERE agent_id = ?';
+    args.push(agent_id);
+  }
+
+  sql += ' ORDER BY created_at DESC LIMIT ?';
+  args.push(limit);
+
+  const result = await db.execute({ sql, args });
+
+  return result.rows.map(row => ({
+    id: row.id as string,
+    created_at: row.created_at as string,
+    agent_id: row.agent_id as string,
+    machine_id: row.machine_id as string,
+    session_id: row.session_id as string,
+    summary: row.summary as string,
+    tasks_touched: JSON.parse((row.tasks_touched as string) || '[]') as string[],
+    status: row.status as WorklogEntry['status'],
+    tags: JSON.parse((row.tags as string) || '[]') as string[],
+  }));
+}
+
+/**
+ * Get a single worklog entry by ID
+ */
+export async function get_worklog_entry(id: string): Promise<WorklogEntry | null> {
+  await ensure_worklog_schema();
+  const db = get_client();
+
+  const result = await db.execute({
+    sql: 'SELECT * FROM worklog WHERE id = ?',
+    args: [id]
+  });
+
+  if (result.rows.length === 0) return null;
+
+  const row = result.rows[0];
+  return {
+    id: row.id as string,
+    created_at: row.created_at as string,
+    agent_id: row.agent_id as string,
+    machine_id: row.machine_id as string,
+    session_id: row.session_id as string,
+    summary: row.summary as string,
+    tasks_touched: JSON.parse((row.tasks_touched as string) || '[]') as string[],
+    status: row.status as WorklogEntry['status'],
+    tags: JSON.parse((row.tags as string) || '[]') as string[],
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,6 @@ export async function proxy(request: NextRequest) {
 export const config = {
   // Protect all routes except login, story, archive, games, privacy, terms, api/auth, api/health, api/suggestions, api/stories, api/prompts, api/oura/callback, and static files
   matcher: [
-    '/((?!login|story|archive|creative/archive|games|privacy|terms|api/auth|api/health|api/suggestions|api/stories|api/prompts|api/oura|_next/static|_next/image|favicon.ico|icon.svg).*)',
+    '/((?!login|story|archive|creative/archive|games|privacy|terms|api/auth|api/health|api/suggestions|api/stories|api/prompts|api/oura|api/worklog|_next/static|_next/image|favicon.ico|icon.svg).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- New `/api/worklog` endpoint for agent session worklog entries (drift prevention system)
- Worklog table added to Turso with auto-init schema migration (same pattern as suggestions/prompts)
- `GET /api/worklog` is public (supports `?limit=N&agent_id=X` params)
- `POST /api/worklog` requires `X-Worklog-Key` header for write auth
- Worklog `id` is server-generated UUID; `session_id` is client-generated UUID (validated)
- Route added to public matcher in `proxy.ts`

## Files changed
- `src/app/api/worklog/route.ts` — new API route (GET/POST/OPTIONS)
- `src/lib/db.ts` — worklog table schema, `create_worklog_entry()`, `get_worklog_entries()`, `get_worklog_entry()`
- `src/proxy.ts` — added `api/worklog` to public route matcher

## Required env var
- **`WORKLOG_API_KEY`** must be set in Vercel before merge. POST returns 503 if not configured, 401 if key does not match. This is the only auth method for writes — no guest PIN fallback.

## Test plan
- [ ] Set `WORKLOG_API_KEY` in Vercel env settings
- [ ] Deploy and verify `GET /api/worklog` returns `{ success: true, entries: [], count: 0 }`
- [ ] POST a worklog entry with `X-Worklog-Key` header and verify 200
- [ ] POST without key and verify 401
- [ ] POST with invalid `session_id` (non-UUID) and verify 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)