### PR TITLE
Add CRLF troubleshooting note to Session End Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,9 @@ Status values: `info` (normal), `warning` (something needs attention), `blocked`
 
 Write only on session end. Not mid-session.
 
+If POST fails with 401/400 on penguin, check for CRLF in `~/.profile` and normalize
+line endings: `sed -i 's/\r$//' ~/.profile && source ~/.profile`
+
 ---
 
 ## 7. Truth Hierarchy


### PR DESCRIPTION
## Summary
- Adds a troubleshooting note to AGENTS.md Section 6 (Session End Protocol)
- When env vars are piped from Windows to Linux, CRLF can poison HTTP headers causing 401/400
- Provides the fix command: `sed -i 's/\r$//' ~/.profile && source ~/.profile`

## Files changed
- `AGENTS.md` -- 3 lines added to Session End Protocol section

🤖 Generated with [Claude Code](https://claude.com/claude-code)