### PR TITLE
Merge chip/remove-chipboard: add Python cache .gitignore exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 
 # local database
 /data
+
+# python
+__pycache__/
+*.pyc


### PR DESCRIPTION
Final commit from chip/remove-chipboard branch — adds Python cache exclusions to .gitignore for mr_bear module. Branch will be deleted after merge.