### PR TITLE
Fix knowledge diff appendix: include source doc in prompt

### DIFF
--- a/src/app/api/knowledge-diff/route.ts
+++ b/src/app/api/knowledge-diff/route.ts
@@ -151,7 +151,10 @@ Rules:
 - Organize under a "## Appendix" header with brief sub-headers for each recovered item
 
 VERIFIED_LOSSES:
-${analysis}`;
+${analysis}
+
+OLD DOCUMENT (source for exact quotes):
+${old_doc}`;
 
       const result = await client.messages.create({
         model,


### PR DESCRIPTION
## Summary
- Appendix prompt now includes `old_doc` so the AI has source material to pull exact quotes from
- Root cause: `old_doc` was required but never passed into the prompt template

Closes #126

## Test plan
- [ ] Run a knowledge diff with two docs where losses exist
- [ ] Verify the appendix section now generates with recovered content
- [ ] Verify exact quotes from the old document appear in the appendix