### PR TITLE
Mobile Pass B: stack layouts and tap targets

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -164,7 +164,7 @@ export default function HomePage() {
                 <p className="text-gray-400 text-sm leading-relaxed mb-3">{cat.description}</p>
 
                 {/* Tool links */}
-                <div className="flex flex-wrap gap-1.5 mb-1">
+                <div className="flex flex-col sm:flex-row flex-wrap gap-1.5 mb-1">
                   {cat.links.map((link) => (
                     <Link key={link.label} href={link.href}
                       className="px-2 py-1 text-xs rounded bg-white/5 border border-purple-400/20 text-purple-400/80 hover:text-purple-400 hover:bg-white/10 transition-colors">

--- a/src/app/tools/knowledge-diff/page.tsx
+++ b/src/app/tools/knowledge-diff/page.tsx
@@ -168,7 +168,7 @@ export default function KnowledgeDiffPage() {
           Compare two knowledge documents to detect potential information loss
         </p>
 
-        <div style={{
+        <div className="knowledge-diff-grid" style={{
           display: 'grid',
           gridTemplateColumns: '1fr 1fr',
           gap: '20px',
@@ -453,6 +453,10 @@ export default function KnowledgeDiffPage() {
         )}
         <style jsx>{`
           @media (max-width: 768px) {
+            .knowledge-diff-grid {
+              grid-template-columns: 1fr !important;
+            }
+
             .knowledge-diff-actions {
               flex-direction: column;
               align-items: stretch !important;

--- a/src/app/tools/prompt-library/page.tsx
+++ b/src/app/tools/prompt-library/page.tsx
@@ -486,7 +486,7 @@ export default function PromptLibraryPage() {
               <div
                 key={p.id}
                 onClick={() => open_prompt(p.id)}
-                className="w-full text-left p-4 bg-white/5 border border-white/10 rounded-lg hover:border-cyan-400/30 hover:bg-white/[0.07] transition-all group cursor-pointer"
+                className="w-full text-left p-4 bg-white/5 border border-white/10 rounded-lg hover:border-cyan-400/30 hover:bg-white/[0.07] transition-all group cursor-pointer min-h-[44px] sm:min-h-0"
               >
                 <div className="flex items-center justify-between">
                   <div className="min-w-0 flex-1">
@@ -521,7 +521,7 @@ export default function PromptLibraryPage() {
                         set_copied_id(p.id);
                         setTimeout(() => set_copied_id(null), 2000);
                       }}
-                      className="px-2 py-1 text-xs bg-white/5 text-gray-500 hover:text-cyan-400 hover:bg-white/10 rounded transition-all"
+                      className="min-h-[44px] sm:min-h-0 px-3 py-2 sm:py-1 text-xs bg-white/5 text-gray-500 hover:text-cyan-400 hover:bg-white/10 rounded transition-all"
                       title="Copy prompt to clipboard"
                     >
                       {copied_id === p.id ? 'Copied!' : 'Copy'}


### PR DESCRIPTION
## Summary
- Knowledge Diff: OLD/NEW textareas stack vertically on mobile (single-column grid)
- Prompt Library: rows and Copy buttons get 44px min tap targets on mobile
- Home page: tool chip links stack vertically on mobile, wrap horizontally on desktop

3 files changed, CSS/Tailwind only, desktop unchanged.

Issue #131

## Test plan
- [ ] Knowledge Diff on phone: textareas stacked, no horizontal scroll
- [ ] Prompt Library on phone: rows comfortable to tap, Copy button reachable
- [ ] Home page on phone: tool links scannable without zoom
- [ ] All three pages unchanged on desktop