### PR TITLE
F1: raise game-wide text contrast to WCAG AA

### DIFF
--- a/src/app/games/f1/page.tsx
+++ b/src/app/games/f1/page.tsx
@@ -466,7 +466,7 @@ export default function F1Page() {
           vertical-align: baseline;
         }
         .f1-subtitle {
-          color: #a1a1aa;
+          color: #d1d5db;
           font-size: 0.85rem;
         }
         .player-bar {
@@ -497,7 +497,7 @@ export default function F1Page() {
           border-top: 1px solid rgba(255,255,255,0.05);
         }
         .other-years-label {
-          color: #a1a1aa;
+          color: #d1d5db;
           font-size: 0.7rem;
           text-transform: uppercase;
           letter-spacing: 0.05em;
@@ -506,7 +506,7 @@ export default function F1Page() {
         .year-btn {
           background: rgba(255,255,255,0.04);
           border: 1px solid rgba(255,255,255,0.05);
-          color: #a1a1aa;
+          color: #d1d5db;
           border-radius: 6px;
           padding: 0.3rem 0.75rem;
           cursor: pointer;
@@ -550,7 +550,7 @@ export default function F1Page() {
               </button>
               <button
                 onClick={() => set_setup_banner_dismissed(true)}
-                style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: '1rem', lineHeight: 1 }}
+                style={{ background: 'none', border: 'none', color: '#d1d5db', cursor: 'pointer', fontSize: '1rem', lineHeight: 1 }}
               >
                 ✕
               </button>
@@ -565,7 +565,7 @@ export default function F1Page() {
             borderRadius: '8px', padding: '0.6rem 0.75rem', marginBottom: '1rem',
             display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem',
           }}>
-            <span style={{ color: '#bbb', fontSize: '0.8rem' }}>Playing as:</span>
+            <span style={{ color: '#d1d5db', fontSize: '0.8rem' }}>Playing as:</span>
             {roster.map(name => (
               <button
                 key={name}
@@ -588,10 +588,10 @@ export default function F1Page() {
             background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)',
             borderRadius: '8px', padding: '1rem', marginBottom: '1rem', textAlign: 'center',
           }}>
-            <div style={{ color: '#bbb', fontSize: '0.85rem', marginBottom: '0.75rem' }}>
+            <div style={{ color: '#d1d5db', fontSize: '0.85rem', marginBottom: '0.75rem' }}>
               No players on the roster yet.
             </div>
-            <div style={{ color: '#aaa', fontSize: '0.8rem', marginBottom: '0.5rem' }}>Browse previous seasons:</div>
+            <div style={{ color: '#d1d5db', fontSize: '0.8rem', marginBottom: '0.5rem' }}>Browse previous seasons:</div>
             <button className="year-btn" onClick={() => { set_season(s => s - 1); set_selected_round(null); }}>
               &larr; {season - 1}
             </button>
@@ -616,7 +616,7 @@ export default function F1Page() {
                   style={{
                     background: show_roster ? 'rgba(225,6,0,0.15)' : 'none',
                     border: 'none',
-                    color: show_roster ? '#e10600' : '#aaa',
+                    color: show_roster ? '#e10600' : '#d1d5db',
                     cursor: 'pointer',
                     fontSize: '1rem',
                     padding: '0.2rem',
@@ -658,7 +658,7 @@ export default function F1Page() {
 
         {/* Loading / Error */}
         {loading && !selected_round && (
-          <div style={{ textAlign: 'center', color: '#bbb', padding: '2rem' }}>
+          <div style={{ textAlign: 'center', color: '#d1d5db', padding: '2rem' }}>
             Loading {season} schedule...
           </div>
         )}
@@ -709,7 +709,7 @@ export default function F1Page() {
                     }}
                   />
                 ) : (
-                  <div style={{ textAlign: 'center', color: '#bbb', padding: '2rem' }}>
+                  <div style={{ textAlign: 'center', color: '#d1d5db', padding: '2rem' }}>
                     No races found for {season}. Try a different year.
                   </div>
                 )}
@@ -728,7 +728,7 @@ export default function F1Page() {
           </>
         )}
         <div style={{ textAlign: 'center', marginTop: '3rem', paddingBottom: '1rem' }}>
-          <a href="/" style={{ color: '#aaa', fontSize: '0.7rem', textDecoration: 'none' }}>8i11</a>
+          <a href="/" style={{ color: '#d1d5db', fontSize: '0.7rem', textDecoration: 'none' }}>8i11</a>
         </div>
       </div>
       </div>

--- a/src/components/f1/activity_hud.tsx
+++ b/src/components/f1/activity_hud.tsx
@@ -83,14 +83,14 @@ export default function ActivityHud({ entries }: ActivityHudProps) {
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
             <span style={{ color: '#e10600', fontSize: '0.6rem' }}>●</span>
-            <span style={{ color: '#a1a1aa', fontSize: '0.7rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            <span style={{ color: '#d1d5db', fontSize: '0.7rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
               Live Activity
             </span>
             {entries.length > 0 && (
-              <span style={{ color: '#aaa', fontSize: '0.65rem' }}>({entries.length})</span>
+              <span style={{ color: '#d1d5db', fontSize: '0.65rem' }}>({entries.length})</span>
             )}
           </div>
-          <span style={{ color: '#aaa', fontSize: '0.65rem' }}>{expanded ? '▼' : '▲'}</span>
+          <span style={{ color: '#d1d5db', fontSize: '0.65rem' }}>{expanded ? '▼' : '▲'}</span>
         </div>
 
         {/* Feed */}
@@ -104,7 +104,7 @@ export default function ActivityHud({ entries }: ActivityHudProps) {
             overflowY: 'auto',
           }}>
             {entries.length === 0 ? (
-              <div style={{ color: '#aaa', fontSize: '0.72rem', padding: '0.75rem', textAlign: 'center' }}>
+              <div style={{ color: '#d1d5db', fontSize: '0.72rem', padding: '0.75rem', textAlign: 'center' }}>
                 No activity yet — waiting for picks
               </div>
             ) : (
@@ -118,9 +118,9 @@ export default function ActivityHud({ entries }: ActivityHudProps) {
                 }}>
                   <span style={{ color: '#fff', fontWeight: 600 }}>{e.player_name}</span>
                   {' '}
-                  <span style={{ color: '#bbb' }}>{e.text}</span>
+                  <span style={{ color: '#d1d5db' }}>{e.text}</span>
                   {!e.status && (
-                    <div style={{ color: '#aaa', fontSize: '0.62rem', marginTop: '0.1rem' }}>
+                    <div style={{ color: '#d1d5db', fontSize: '0.62rem', marginTop: '0.1rem' }}>
                       {relative_time(e.ts)}
                     </div>
                   )}

--- a/src/components/f1/group_picks.tsx
+++ b/src/components/f1/group_picks.tsx
@@ -35,7 +35,7 @@ export default function GroupPicks({ predictions, drivers, show_fastest_lap }: G
       border: '1px solid rgba(255,255,255,0.05)',
       borderRadius: '10px',
     }}>
-      <div style={{ color: '#a1a1aa', fontSize: '0.75rem', fontWeight: 700, marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+      <div style={{ color: '#d1d5db', fontSize: '0.75rem', fontWeight: 700, marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
         {all_locked ? 'All Picks Locked In' : 'Picks So Far'}
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: `repeat(${predictions.length}, 1fr)`, gap: '0.5rem' }}>
@@ -51,7 +51,7 @@ export default function GroupPicks({ predictions, drivers, show_fastest_lap }: G
               <span style={{ color: '#e0e0e0', fontSize: '0.8rem', fontWeight: 700 }}>
                 {pred.player_name}
               </span>
-              <span style={{ fontSize: '0.65rem', color: pred.is_locked ? '#ffffff' : '#bbb' }}>
+              <span style={{ fontSize: '0.65rem', color: pred.is_locked ? '#ffffff' : '#d1d5db' }}>
                 {pred.is_locked ? '🔒' : '·'}
               </span>
             </div>
@@ -65,7 +65,7 @@ export default function GroupPicks({ predictions, drivers, show_fastest_lap }: G
               P3: {driver_label(pred.p3, drivers)}
             </div>
             {show_fastest_lap && pred.fastest_lap && (
-              <div style={{ color: '#7c3aed', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+              <div style={{ color: '#a78bfa', fontSize: '0.8rem', marginTop: '0.25rem' }}>
                 FL: {driver_label(pred.fastest_lap, drivers)}
               </div>
             )}

--- a/src/components/f1/leaderboard.tsx
+++ b/src/components/f1/leaderboard.tsx
@@ -23,7 +23,7 @@ function ScoringRules() {
         style={{
           background: 'none',
           border: 'none',
-          color: '#bbb',
+          color: '#d1d5db',
           cursor: 'pointer',
           fontSize: '0.8rem',
           padding: 0,
@@ -46,12 +46,12 @@ function ScoringRules() {
             <span style={{ color: '#ccc' }}>Perfect Match — right driver, right position</span>
             <span style={{ color: '#d4a017', fontWeight: 700 }}>+2</span>
             <span style={{ color: '#ccc' }}>Podium Lock — right driver, wrong position</span>
-            <span style={{ color: '#bbb', fontWeight: 700 }}>+1</span>
+            <span style={{ color: '#d1d5db', fontWeight: 700 }}>+1</span>
             <span style={{ color: '#ccc' }}>Almost — driver finishes P4 or P5</span>
-            <span style={{ color: '#7c3aed', fontWeight: 700 }}>+3</span>
+            <span style={{ color: '#a78bfa', fontWeight: 700 }}>+3</span>
             <span style={{ color: '#ccc' }}>Fastest Lap — bonus for race sessions only</span>
           </div>
-          <div style={{ color: '#aaa', fontSize: '0.75rem', marginTop: '0.5rem' }}>
+          <div style={{ color: '#d1d5db', fontSize: '0.75rem', marginTop: '0.5rem' }}>
             Max per session: 18 pts (3 perfect + fastest lap)
           </div>
         </div>
@@ -69,7 +69,7 @@ export default function Leaderboard({ standings, season }: LeaderboardProps) {
           borderRadius: '10px',
           padding: '1.5rem',
           textAlign: 'center',
-          color: '#aaa',
+          color: '#d1d5db',
           fontSize: '0.85rem',
         }}>
           No predictions yet for {season}. Be the first to play!
@@ -93,7 +93,7 @@ export default function Leaderboard({ standings, season }: LeaderboardProps) {
           display: 'grid',
           gridTemplateColumns: '32px 1fr 56px 56px',
           padding: '0.6rem 0.85rem',
-          color: '#a1a1aa',
+          color: '#d1d5db',
           fontSize: '0.7rem',
           fontWeight: 700,
           textTransform: 'uppercase',
@@ -114,7 +114,7 @@ export default function Leaderboard({ standings, season }: LeaderboardProps) {
             background: i % 2 === 1 ? 'rgba(255,255,255,0.03)' : 'transparent',
           }}>
             <div style={{
-              color: i === 0 ? '#ffd700' : i === 1 ? '#c0c0c0' : i === 2 ? '#cd7f32' : '#bbb',
+              color: i === 0 ? '#ffd700' : i === 1 ? '#c0c0c0' : i === 2 ? '#cd7f32' : '#d1d5db',
               fontWeight: 700,
               fontSize: '0.9rem',
             }}>
@@ -123,7 +123,7 @@ export default function Leaderboard({ standings, season }: LeaderboardProps) {
             <div style={{ color: '#ffffff', fontSize: '0.9rem', fontWeight: 500 }}>
               {entry.player_name}
             </div>
-            <div style={{ color: '#a1a1aa', fontSize: '0.85rem', textAlign: 'right' }}>
+            <div style={{ color: '#d1d5db', fontSize: '0.85rem', textAlign: 'right' }}>
               {entry.sessions_played}
             </div>
             <div style={{

--- a/src/components/f1/player_picker.tsx
+++ b/src/components/f1/player_picker.tsx
@@ -35,7 +35,7 @@ export default function PlayerPicker({ roster, on_claim }: PlayerPickerProps) {
 
         {roster.length > 0 ? (
           <>
-            <div style={{ color: '#bbb', fontSize: '0.8rem', marginTop: '0.5rem' }}>
+            <div style={{ color: '#d1d5db', fontSize: '0.8rem', marginTop: '0.5rem' }}>
               Pick your name from the roster
             </div>
             <div style={{ margin: '1rem 0', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
@@ -58,12 +58,12 @@ export default function PlayerPicker({ roster, on_claim }: PlayerPickerProps) {
                 </button>
               ))}
             </div>
-            <div style={{ color: '#aaa', fontSize: '0.75rem' }}>
+            <div style={{ color: '#d1d5db', fontSize: '0.75rem' }}>
               Don&apos;t see your name? Ask the admin to add you to the roster, then refresh.
             </div>
           </>
         ) : (
-          <div style={{ color: '#bbb', fontSize: '0.85rem', marginTop: '1rem', lineHeight: 1.5 }}>
+          <div style={{ color: '#d1d5db', fontSize: '0.85rem', marginTop: '1rem', lineHeight: 1.5 }}>
             No players on the roster yet.<br />
             Ask the admin to add you, then refresh.
           </div>

--- a/src/components/f1/prediction_form.tsx
+++ b/src/components/f1/prediction_form.tsx
@@ -53,7 +53,7 @@ function DriverTypeAhead({
 
   return (
     <div style={{ marginBottom: '0.75rem', position: 'relative' }} ref={ref}>
-      <label style={{ color: '#aaa', fontSize: '0.75rem', display: 'block', marginBottom: '0.25rem' }}>
+      <label style={{ color: '#d1d5db', fontSize: '0.75rem', display: 'block', marginBottom: '0.25rem' }}>
         {label}
       </label>
       <input
@@ -78,7 +78,7 @@ function DriverTypeAhead({
           onClick={() => { on_change(''); set_query(''); set_open(true); }}
           style={{
             position: 'absolute', right: '8px', top: '26px',
-            background: 'none', border: 'none', color: '#bbb', cursor: 'pointer', fontSize: '0.8rem',
+            background: 'none', border: 'none', color: '#d1d5db', cursor: 'pointer', fontSize: '0.8rem',
           }}
         >
           x
@@ -99,7 +99,7 @@ function DriverTypeAhead({
           marginTop: '2px',
         }}>
           {filtered.length === 0 ? (
-            <div style={{ padding: '0.5rem', color: '#aaa', fontSize: '0.85rem' }}>No matches</div>
+            <div style={{ padding: '0.5rem', color: '#d1d5db', fontSize: '0.85rem' }}>No matches</div>
           ) : (
             filtered.map(d => (
               <button
@@ -122,7 +122,7 @@ function DriverTypeAhead({
               >
                 <span style={{ color: '#e10600', fontWeight: 700, marginRight: '0.4rem' }}>{d.code}</span>
                 {d.given_name} {d.family_name}
-                <span style={{ color: '#aaa', marginLeft: '0.4rem', fontSize: '0.75rem' }}>({d.constructor_name})</span>
+                <span style={{ color: '#d1d5db', marginLeft: '0.4rem', fontSize: '0.75rem' }}>({d.constructor_name})</span>
               </button>
             ))
           )}
@@ -175,7 +175,7 @@ export default function PredictionForm({
           style={{
             flex: 1,
             background: can_submit ? '#e10600' : '#444',
-            color: can_submit ? '#ffffff' : '#aaa',
+            color: can_submit ? '#ffffff' : '#d1d5db',
             border: 'none',
             borderRadius: '6px',
             padding: '0.6rem',
@@ -190,7 +190,7 @@ export default function PredictionForm({
           onClick={on_cancel}
           style={{
             background: 'transparent',
-            color: '#bbb',
+            color: '#d1d5db',
             border: '1px solid #444',
             borderRadius: '6px',
             padding: '0.6rem 1rem',

--- a/src/components/f1/results_reveal.tsx
+++ b/src/components/f1/results_reveal.tsx
@@ -20,8 +20,8 @@ interface ResultsRevealProps {
 function score_color(pick: string, position: number, actual_podium: string[], actual_p4_p5: string[]): string {
   if (pick === actual_podium[position]) return '#00d672'; // perfect match - green
   if (actual_podium.includes(pick)) return '#d4a017';     // podium lock - amber/gold
-  if (actual_p4_p5.includes(pick)) return '#bbb';         // almost - gray
-  return '#777';                                            // miss - dim
+  if (actual_p4_p5.includes(pick)) return '#d1d5db';      // almost - light gray
+  return '#999';                                            // miss - dim
 }
 
 function score_label(pick: string, position: number, actual_podium: string[], actual_p4_p5: string[]): string {
@@ -73,15 +73,15 @@ export default function ResultsReveal({
               borderRadius: '6px',
               borderLeft: `3px solid ${color}`,
             }}>
-              <div style={{ color: '#bbb', fontWeight: 700, fontSize: '0.9rem' }}>{pos}</div>
+              <div style={{ color: '#d1d5db', fontWeight: 700, fontSize: '0.9rem' }}>{pos}</div>
               <div>
-                <div style={{ color: '#bbb', fontSize: '0.65rem' }}>{pick_label}</div>
-                <div style={{ color: pick ? '#e0e0e0' : '#aaa', fontSize: '0.85rem' }}>
+                <div style={{ color: '#d1d5db', fontSize: '0.65rem' }}>{pick_label}</div>
+                <div style={{ color: pick ? '#e0e0e0' : '#d1d5db', fontSize: '0.85rem' }}>
                   {pick ? driver_display(pick, results) : 'No pick'}
                 </div>
               </div>
               <div>
-                <div style={{ color: '#bbb', fontSize: '0.65rem' }}>ACTUAL</div>
+                <div style={{ color: '#d1d5db', fontSize: '0.65rem' }}>ACTUAL</div>
                 <div style={{ color: '#e0e0e0', fontSize: '0.85rem' }}>
                   {actual_driver ? `${actual_driver.driver_code} - ${actual_driver.given_name} ${actual_driver.family_name}` : '-'}
                 </div>
@@ -107,27 +107,27 @@ export default function ResultsReveal({
           padding: '0.5rem',
           background: 'rgba(255,255,255,0.03)',
           borderRadius: '6px',
-          borderLeft: `3px solid ${prediction.fastest_lap === fastest_lap_driver_id ? '#7c3aed' : '#555'}`,
+          borderLeft: `3px solid ${prediction.fastest_lap === fastest_lap_driver_id ? '#a78bfa' : '#555'}`,
           display: 'grid',
           gridTemplateColumns: '40px 1fr 1fr auto',
           gap: '0.5rem',
           alignItems: 'center',
         }}>
-          <div style={{ color: '#bbb', fontWeight: 700, fontSize: '0.85rem' }}>FL</div>
+          <div style={{ color: '#d1d5db', fontWeight: 700, fontSize: '0.85rem' }}>FL</div>
           <div>
-            <div style={{ color: '#888', fontSize: '0.65rem' }}>{pick_label}</div>
+            <div style={{ color: '#d1d5db', fontSize: '0.65rem' }}>{pick_label}</div>
             <div style={{ color: '#e0e0e0', fontSize: '0.85rem' }}>
               {driver_display(prediction.fastest_lap, results)}
             </div>
           </div>
           <div>
-            <div style={{ color: '#888', fontSize: '0.65rem' }}>ACTUAL</div>
+            <div style={{ color: '#d1d5db', fontSize: '0.65rem' }}>ACTUAL</div>
             <div style={{ color: '#e0e0e0', fontSize: '0.85rem' }}>
               {fastest_lap_driver_id ? driver_display(fastest_lap_driver_id, results) : 'N/A'}
             </div>
           </div>
           <div style={{
-            color: prediction.fastest_lap === fastest_lap_driver_id ? '#7c3aed' : '#555',
+            color: prediction.fastest_lap === fastest_lap_driver_id ? '#a78bfa' : '#555',
             fontWeight: 700,
             fontSize: '0.8rem',
             textAlign: 'right',
@@ -147,11 +147,11 @@ export default function ResultsReveal({
           borderRadius: '8px',
           textAlign: 'center',
         }}>
-          <div style={{ color: '#bbb', fontSize: '0.75rem', marginBottom: '0.25rem' }}>SESSION TOTAL</div>
+          <div style={{ color: '#d1d5db', fontSize: '0.75rem', marginBottom: '0.25rem' }}>SESSION TOTAL</div>
           <div style={{ color: '#ffffff', fontSize: '2rem', fontWeight: 700 }}>
             {score.total} pts
           </div>
-          <div style={{ color: '#bbb', fontSize: '0.75rem', marginTop: '0.25rem' }}>
+          <div style={{ color: '#d1d5db', fontSize: '0.75rem', marginTop: '0.25rem' }}>
             {score.perfect_match > 0 && `${score.perfect_match} perfect `}
             {score.podium_lock > 0 && `${score.podium_lock} podium `}
             {score.almost > 0 && `${score.almost} almost `}
@@ -167,7 +167,7 @@ export default function ResultsReveal({
           background: 'rgba(255,255,255,0.03)',
           borderRadius: '8px',
           textAlign: 'center',
-          color: '#bbb',
+          color: '#d1d5db',
           fontSize: '0.85rem',
         }}>
           No prediction was made for this session

--- a/src/components/f1/results_table.tsx
+++ b/src/components/f1/results_table.tsx
@@ -35,8 +35,8 @@ function grade_pick(pick: string, position: number, podium: string[], p4_p5: str
 const grade_colors: Record<PickGrade, string> = {
   perfect: '#00d672',
   podium: '#d4a017',
-  almost: '#bbb',
-  miss: '#777',
+  almost: '#d1d5db',
+  miss: '#999',
 };
 
 const grade_points: Record<PickGrade, string> = {
@@ -71,18 +71,18 @@ export default function ResultsTable({
         alignItems: 'center',
         flexWrap: 'wrap',
       }}>
-        <span style={{ color: '#bbb', fontSize: '0.7rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        <span style={{ color: '#d1d5db', fontSize: '0.7rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
           Results
         </span>
         {results.slice(0, 3).map((r, i) => (
           <span key={r.driver_id} style={{ color: '#ffffff', fontSize: '0.85rem', fontWeight: 600 }}>
-            <span style={{ color: '#aaa', fontSize: '0.75rem' }}>P{i + 1}</span>{' '}
+            <span style={{ color: '#d1d5db', fontSize: '0.75rem' }}>P{i + 1}</span>{' '}
             {r.driver_code}
           </span>
         ))}
         {show_fl && fastest_lap_driver_id && (
-          <span style={{ color: '#7c3aed', fontSize: '0.85rem', fontWeight: 600 }}>
-            <span style={{ color: '#aaa', fontSize: '0.75rem' }}>FL</span>{' '}
+          <span style={{ color: '#a78bfa', fontSize: '0.85rem', fontWeight: 600 }}>
+            <span style={{ color: '#d1d5db', fontSize: '0.75rem' }}>FL</span>{' '}
             {driver_code(fastest_lap_driver_id, results)}
           </span>
         )}
@@ -166,14 +166,14 @@ export default function ResultsTable({
                 {pred.fastest_lap ? (
                   <>
                     <div style={{
-                      color: fl_correct ? '#7c3aed' : '#aaa',
+                      color: fl_correct ? '#a78bfa' : '#d1d5db',
                       fontSize: '0.85rem',
                       fontWeight: 700,
                     }}>
                       {driver_code(pred.fastest_lap, results)}
                     </div>
                     <div style={{
-                      color: fl_correct ? '#7c3aed' : '#aaa',
+                      color: fl_correct ? '#a78bfa' : '#d1d5db',
                       fontSize: '0.65rem',
                       opacity: 0.8,
                     }}>
@@ -181,7 +181,7 @@ export default function ResultsTable({
                     </div>
                   </>
                 ) : (
-                  <div style={{ color: '#aaa', fontSize: '0.75rem' }}>—</div>
+                  <div style={{ color: '#d1d5db', fontSize: '0.75rem' }}>—</div>
                 )}
               </div>
             )}
@@ -206,7 +206,7 @@ export default function ResultsTable({
 }
 
 const header_style: React.CSSProperties = {
-  color: '#aaa',
+  color: '#d1d5db',
   fontSize: '0.7rem',
   fontWeight: 700,
   textTransform: 'uppercase',

--- a/src/components/f1/roster_manager.tsx
+++ b/src/components/f1/roster_manager.tsx
@@ -146,7 +146,7 @@ export default function RosterManager({ season, round, roster, on_roster_change,
       <div style={{ color: '#e10600', fontSize: '0.8rem', fontWeight: 700, marginBottom: '0.25rem' }}>
         Roster Manager
       </div>
-      <div style={{ color: '#bbb', fontSize: '0.7rem', marginBottom: '0.5rem' }}>
+      <div style={{ color: '#d1d5db', fontSize: '0.7rem', marginBottom: '0.5rem' }}>
         Add yourself first before adding other players.
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginBottom: '0.5rem' }}>
@@ -181,7 +181,7 @@ export default function RosterManager({ season, round, roster, on_roster_change,
           </span>
         ))}
         {roster.length === 0 && (
-          <span style={{ color: '#aaa', fontSize: '0.8rem' }}>No players added yet</span>
+          <span style={{ color: '#d1d5db', fontSize: '0.8rem' }}>No players added yet</span>
         )}
       </div>
       <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
@@ -258,7 +258,7 @@ export default function RosterManager({ season, round, roster, on_roster_change,
             >
               Poke the Bear
             </button>
-            {!round && <span style={{ color: '#aaa', fontSize: '0.7rem' }}>Select a round first</span>}
+            {!round && <span style={{ color: '#d1d5db', fontSize: '0.7rem' }}>Select a round first</span>}
           </div>
           {poke_result && (
             <div style={{ color: '#d4a574', fontSize: '0.75rem', marginTop: '0.35rem' }}>

--- a/src/components/f1/season_grid.tsx
+++ b/src/components/f1/season_grid.tsx
@@ -81,19 +81,19 @@ export default function SeasonGrid({ races, on_select_round, active_round, compl
                 e.currentTarget.style.background = is_future ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.04)';
               }}
             >
-              <div style={{ fontSize: '0.7rem', color: '#a1a1aa', marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' }}>
+              <div style={{ fontSize: '0.7rem', color: '#d1d5db', marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' }}>
                 <span>R{race.round} {get_flag(race.country)}</span>
                 {is_completed && (
-                  <span style={{ color: '#a1a1aa', fontSize: '0.6rem', fontWeight: 700, background: 'rgba(255,255,255,0.06)', padding: '1px 5px', borderRadius: '3px' }}>DONE</span>
+                  <span style={{ color: '#d1d5db', fontSize: '0.6rem', fontWeight: 700, background: 'rgba(255,255,255,0.06)', padding: '1px 5px', borderRadius: '3px' }}>DONE</span>
                 )}
                 {is_active && (
                   <span style={{ color: '#e10600', fontSize: '0.6rem', fontWeight: 700, background: 'rgba(225,6,0,0.1)', padding: '1px 5px', borderRadius: '3px' }}>NEXT</span>
                 )}
               </div>
-              <div style={{ color: is_future ? '#aaa' : '#ffffff', fontSize: '0.9rem', fontWeight: 600, marginBottom: '0.3rem' }}>
+              <div style={{ color: is_future ? '#d1d5db' : '#ffffff', fontSize: '0.9rem', fontWeight: 600, marginBottom: '0.3rem' }}>
                 {race.race_name.replace(' Grand Prix', ' GP')}
               </div>
-              <div style={{ color: '#a1a1aa', fontSize: '0.75rem' }}>
+              <div style={{ color: '#d1d5db', fontSize: '0.75rem' }}>
                 {format_date(race.race_date)}
                 {race.is_sprint_weekend && (
                   <span style={{

--- a/src/components/f1/weekend_view.tsx
+++ b/src/components/f1/weekend_view.tsx
@@ -97,7 +97,7 @@ export default function WeekendView({
         <h2 style={{ color: '#ffffff', fontSize: '1.25rem', marginBottom: '0.25rem' }}>
           R{race.round} {race.race_name}
         </h2>
-        <div style={{ color: '#a1a1aa', fontSize: '0.85rem' }}>
+        <div style={{ color: '#d1d5db', fontSize: '0.85rem' }}>
           {race.circuit_name} &middot; {race.locality}, {race.country} &middot; {format_date(race.race_date)}
         </div>
       </div>
@@ -127,7 +127,7 @@ export default function WeekendView({
               }}>
                 <div>
                   <span style={{
-                    color: is_locked ? '#aaa' : '#ffffff',
+                    color: is_locked ? '#d1d5db' : '#ffffff',
                     fontWeight: 600,
                     fontSize: '1rem',
                   }}>
@@ -142,14 +142,14 @@ export default function WeekendView({
 
                 <div>
                   {is_locked && (
-                    <span style={{ color: '#aaa', fontSize: '0.8rem' }}>
+                    <span style={{ color: '#d1d5db', fontSize: '0.8rem' }}>
                       Complete previous session first
                     </span>
                   )}
                   {/* predicting + no saved picks: show Make Prediction */}
                   {is_predicting && !show_form && !session.prediction && (
                     roster_empty ? (
-                      <span style={{ color: '#aaa', fontSize: '0.8rem' }}>Season not set up</span>
+                      <span style={{ color: '#d1d5db', fontSize: '0.8rem' }}>Season not set up</span>
                     ) : (
                       <button
                         onClick={() => on_predict_click(session.session_type)}
@@ -195,7 +195,7 @@ export default function WeekendView({
                             title={wait_for_saves ? 'Waiting for all players to save picks first' : undefined}
                             style={{
                               background: submitting || wait_for_saves ? '#333' : '#e10600',
-                              color: submitting || wait_for_saves ? '#aaa' : '#ffffff',
+                              color: submitting || wait_for_saves ? '#d1d5db' : '#ffffff',
                               border: 'none',
                               borderRadius: '4px',
                               padding: '0.3rem 0.6rem',
@@ -215,7 +215,7 @@ export default function WeekendView({
                             return <span style={{ color: '#d4a574', fontSize: '0.72rem' }}>Go poke the bear 🐻</span>;
                           }
                           return (
-                            <span style={{ color: '#aaa', fontSize: '0.72rem' }}>
+                            <span style={{ color: '#d1d5db', fontSize: '0.72rem' }}>
                               Waiting for {missing.join(', ')} to save picks
                             </span>
                           );
@@ -230,7 +230,7 @@ export default function WeekendView({
                   )}
                   {is_watching && (!session.group || session.group.all_predicted) && (
                     <div style={{ textAlign: 'right' }}>
-                      <div style={{ color: '#aaa', fontSize: '0.75rem', marginBottom: '0.35rem' }}>
+                      <div style={{ color: '#d1d5db', fontSize: '0.75rem', marginBottom: '0.35rem' }}>
                         Watch the {session_labels[session.session_type]?.toLowerCase() || session.session_type}, then reveal when ready.
                       </div>
                       <button
@@ -238,7 +238,7 @@ export default function WeekendView({
                         disabled={revealing === session.session_type}
                         style={{
                           background: revealing === session.session_type ? '#444' : '#ffffff',
-                          color: revealing === session.session_type ? '#bbb' : '#111111',
+                          color: revealing === session.session_type ? '#d1d5db' : '#111111',
                           border: 'none',
                           borderRadius: '6px',
                           padding: '0.4rem 0.75rem',
@@ -252,7 +252,7 @@ export default function WeekendView({
                     </div>
                   )}
                   {is_revealed && (
-                    <span style={{ color: '#a1a1aa', fontSize: '0.8rem' }}>Revealed</span>
+                    <span style={{ color: '#d1d5db', fontSize: '0.8rem' }}>Revealed</span>
                   )}
                 </div>
               </div>
@@ -265,12 +265,12 @@ export default function WeekendView({
                       .map(id => drivers.find(d => d.driver_id === id)?.code || id)
                       .join(' / ')}
                     {session.session_type === 'race' && session.prediction.fastest_lap && (
-                      <span style={{ color: '#aaa', fontSize: '0.8rem', marginLeft: '0.5rem' }}>
+                      <span style={{ color: '#d1d5db', fontSize: '0.8rem', marginLeft: '0.5rem' }}>
                         FL: {drivers.find(d => d.driver_id === session.prediction!.fastest_lap)?.code || session.prediction.fastest_lap}
                       </span>
                     )}
                   </div>
-                  <div style={{ color: '#aaa', fontSize: '0.75rem', marginTop: '0.2rem' }}>
+                  <div style={{ color: '#d1d5db', fontSize: '0.75rem', marginTop: '0.2rem' }}>
                     Picks saved. Lock in when ready to watch.
                   </div>
                 </div>
@@ -321,7 +321,7 @@ export default function WeekendView({
                   padding: '0.5rem',
                   background: 'rgba(255,255,255,0.03)',
                   borderRadius: '6px',
-                  color: '#bbb',
+                  color: '#d1d5db',
                   fontSize: '0.85rem',
                 }}>
                   Prediction locked. Watch the session, then click Reveal when ready.


### PR DESCRIPTION
## Summary
- Purple `#7c3aed` → `#a78bfa` for Fastest Lap indicators (~6.4:1 ratio)
- Grays `#777`/`#aaa`/`#bbb`/`#a1a1aa`/`#888` → `#999`/`#d1d5db` game-wide
- 11 UI files, visual-only changes, no logic

Ref #133

## Test plan
- [ ] Check Fastest Lap purple is readable on dark background
- [ ] Scan all F1 screens for gray-on-black readability (season grid, predictions, results, leaderboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)