### PR TITLE
Tools: unify tool listings across Home, Tools, and Nav

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import NavTabs from '@/components/nav_tabs';
+import { TOOLS } from '@/lib/tools';
 
 interface HealthData {
   posts: { total: number };
@@ -93,13 +94,8 @@ export default function HomePage() {
       description: 'Utilities for writing, thinking, and building',
       icon: '🛠️',
       color: 'purple',
-      links: [
-        { label: 'What Am I Trying To Say', href: '/tools/text-cleaner' },
-        { label: 'Markdown', href: '/tools/markdown' },
-        { label: 'Instruction Stripper', href: '/tools/instruction-stripper' },
-        { label: 'Knowledge Diff', href: '/tools/knowledge-diff' },
-        { label: 'Prompt Library', href: '/tools/prompt-library' },
-      ],
+      // Links sourced from src/lib/tools.ts — single source of truth
+      links: TOOLS.map((t) => ({ label: t.label, href: t.path })),
     },
     {
       title: 'Creative',

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,12 +1,13 @@
 /**
  * Tools Landing Page
- * Lists all available tools
+ * Lists all available tools — sourced from src/lib/tools.ts
  */
 
 'use client';
 
 import Link from 'next/link';
 import NavTabs from '@/components/nav_tabs';
+import { TOOLS } from '@/lib/tools';
 
 export default function ToolsPage() {
   return (
@@ -21,20 +22,16 @@ export default function ToolsPage() {
         </h1>
 
         <div className="grid gap-4">
-          <Link
-            href="/tools/text-cleaner"
-            className="block bg-white/5 rounded-xl p-6 border border-white/10 hover:border-cyan-400 transition-all"
-          >
-            <h2 className="text-xl text-white mb-2">What Am I Trying To Say</h2>
-            <p className="text-gray-400 text-sm">Paste rough text — get it cleaned up for clarity, then edit and copy</p>
-          </Link>
-          <Link
-            href="/tools/markdown"
-            className="block bg-white/5 rounded-xl p-6 border border-white/10 hover:border-cyan-400 transition-all"
-          >
-            <h2 className="text-xl text-white mb-2">Markdown Converter</h2>
-            <p className="text-gray-400 text-sm">Convert rich text to Markdown and back</p>
-          </Link>
+          {TOOLS.map((tool) => (
+            <Link
+              key={tool.path}
+              href={tool.path}
+              className="block bg-white/5 rounded-xl p-6 border border-white/10 hover:border-cyan-400 transition-all"
+            >
+              <h2 className="text-xl text-white mb-2">{tool.label}</h2>
+              <p className="text-gray-400 text-sm">{tool.description}</p>
+            </Link>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/nav_tabs.tsx
+++ b/src/components/nav_tabs.tsx
@@ -1,6 +1,7 @@
 /**
  * NavTabs - Main navigation header
  * Tabs: Home | Creative | Tools | Health | Games
+ * Tools dropdown sourced from src/lib/tools.ts
  */
 
 'use client';
@@ -9,6 +10,7 @@ import { useState, useRef, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { TOOLS } from '@/lib/tools';
 
 interface NavTabsProps {
   theme?: 'dark' | 'light';
@@ -271,49 +273,23 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
       </div>
     )}
 
-    {/* Tools dropdown menu */}
+    {/* Tools dropdown menu — items sourced from src/lib/tools.ts */}
     {tools_open && (
       <div
         ref={tools_menu_ref}
         style={{ position: 'fixed', top: tools_pos.top, left: tools_pos.left }}
         className={dropdown_class}
       >
-        <Link
-          href="/tools/text-cleaner"
-          onClick={() => set_tools_open(false)}
-          className={dropdown_item_class}
-        >
-          What Am I Trying To Say
-        </Link>
-        <Link
-          href="/tools/markdown"
-          onClick={() => set_tools_open(false)}
-          className={dropdown_item_class}
-        >
-          Markdown Converter
-        </Link>
-        <Link
-          href="/tools/instruction-stripper"
-          onClick={() => set_tools_open(false)}
-          className={dropdown_item_class}
-        >
-          Instruction Stripper
-        </Link>
-        <Link
-          href="/tools/knowledge-diff"
-          onClick={() => set_tools_open(false)}
-          className={dropdown_item_class}
-        >
-          Knowledge Diff
-        </Link>
-        <Link
-          href="/tools/prompt-library"
-          onClick={() => set_tools_open(false)}
-          className={dropdown_item_class}
-        >
-          Prompt Library
-        </Link>
-
+        {TOOLS.map((tool) => (
+          <Link
+            key={tool.path}
+            href={tool.path}
+            onClick={() => set_tools_open(false)}
+            className={dropdown_item_class}
+          >
+            {tool.label}
+          </Link>
+        ))}
       </div>
     )}
 

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared tool metadata — single source of truth for all tool listings.
+ * Used by: home page (src/app/page.tsx), tools landing (src/app/tools/page.tsx),
+ * and nav dropdown (src/components/nav_tabs.tsx).
+ *
+ * Adding a tool here automatically updates all three surfaces.
+ */
+
+export interface ToolMeta {
+  /** Display label used in nav dropdowns and home page mini-links */
+  label: string;
+  /** Route path */
+  path: string;
+  /** Short description shown on the tools landing page */
+  description: string;
+}
+
+export const TOOLS: ToolMeta[] = [
+  {
+    label: 'What Am I Trying To Say',
+    path: '/tools/text-cleaner',
+    description: 'Paste rough text — get it cleaned up for clarity, then edit and copy',
+  },
+  {
+    label: 'Markdown Converter',
+    path: '/tools/markdown',
+    description: 'Convert rich text to Markdown and back',
+  },
+  {
+    label: 'Instruction Stripper',
+    path: '/tools/instruction-stripper',
+    description: 'Strip formatting instructions and meta-commentary from AI-generated text',
+  },
+  {
+    label: 'Knowledge Diff',
+    path: '/tools/knowledge-diff',
+    description: 'Compare knowledge documents to detect information loss',
+  },
+  {
+    label: 'Prompt Library',
+    path: '/tools/prompt-library',
+    description: 'Store, tag, version, and review prompts with AI assistance',
+  },
+];


### PR DESCRIPTION
## Summary
- New shared config `src/lib/tools.ts` with all 5 tools (label, path, description)
- Home page Tools card, `/tools` landing, and Nav dropdown all import from shared config
- `/tools` page now shows all 5 tools (was only showing 2)
- No hardcoded tool lists remain

Ref #121

## Test plan
- [ ] Home page Tools card shows all 5 tools
- [ ] `/tools` landing page shows all 5 tools
- [ ] Nav Tools dropdown shows all 5 tools with correct links
- [ ] All tool links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)