### PR TITLE
Copy blurb: title as h2 + separate blurb paragraph

### DIFF
--- a/src/app/creative/page.tsx
+++ b/src/app/creative/page.tsx
@@ -199,8 +199,10 @@ export default function OnThisDay() {
       if (version === 'simple') {
         html += `<p>${post.year}: <a href="${post.url}">${post.title}</a></p>\n`;
       } else {
-        const blurb_part = post.blurb ? ` – ${post.blurb}` : '';
-        html += `<p>${post.year}: <a href="${post.url}">${post.title}</a>${blurb_part}</p>\n`;
+        html += `<h2>${post.year}: <a href="${post.url}">${post.title}</a></h2>
+`;
+        if (post.blurb) html += `<p>${post.blurb}</p>
+`;
       }
     }
 


### PR DESCRIPTION
## Summary
- **Closes #151**
- "Copy Title & Intro" now outputs each post's title in an `<h2>` heading instead of inline in a `<p>`
- Blurb appears as a separate `<p>` below the title

## Test plan
- [ ] Go to Creative page with posts loaded
- [ ] Click "Copy Title & Intro"
- [ ] Paste into a rich text editor — titles should be headings, blurbs should be body text below

🤖 Generated with [Claude Code](https://claude.com/claude-code)