### PR TITLE
Restrict /coach to admin users

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,7 +114,7 @@ export default function HomePage() {
       icon: '🚴',
       color: 'green',
       links: [
-        { label: 'Coach', href: '/coach' },
+        ...(is_admin ? [{ label: 'Coach', href: '/coach' }] : []),
         { label: 'Oura', href: '/health/oura' },
         { label: 'Strava', href: '/health/strava' },
         { label: 'COROS', href: '/health/coros' },

--- a/src/components/nav_tabs.tsx
+++ b/src/components/nav_tabs.tsx
@@ -198,9 +198,11 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
                   align="start"
                   avoidCollisions
                 >
-                  <DropdownMenu.Item asChild>
-                    <Link href="/coach" className={item_class}>Coach</Link>
-                  </DropdownMenu.Item>
+                  {session && (session.user as { id?: string })?.id !== 'guest' && (
+                    <DropdownMenu.Item asChild>
+                      <Link href="/coach" className={item_class}>Coach</Link>
+                    </DropdownMenu.Item>
+                  )}
                   <DropdownMenu.Item asChild>
                     <Link href="/health/oura" className={item_class}>Oura</Link>
                   </DropdownMenu.Item>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,6 +15,16 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(login_url);
   }
 
+  // /coach and /api/coaching/* are admin-only (non-guest).
+  const path = request.nextUrl.pathname;
+  const is_coach = path === '/coach' || path.startsWith('/coach/') || path.startsWith('/api/coaching');
+  if (is_coach && token.sub === 'guest') {
+    if (path.startsWith('/api/')) {
+      return NextResponse.json({ error: 'Admin only' }, { status: 403 });
+    }
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## Summary
- Proxy now 403s `/api/coaching/*` and redirects `/coach*` to `/` when `token.sub === 'guest'`.
- Nav Health dropdown hides the `Coach` item for guests.
- Landing page Health card omits the `Coach` chip for guests.

## Test plan
- [ ] Admin sees `Coach` in nav and on Health card; `/coach` loads.
- [ ] Guest does not see `Coach`; hitting `/coach` directly redirects to `/`; `/api/coaching/*` returns 403.

https://claude.ai/code/session_01Ht2v2sHrPyGu2ppL5zMc1B