### PR TITLE
Rebuild coaching app: Oura-only, clean UI, no COROS

### DIFF
--- a/src/app/api/coaching/chat/route.ts
+++ b/src/app/api/coaching/chat/route.ts
@@ -1,7 +1,7 @@
 /**
  * API route: POST /api/coaching/chat
- * Multi-turn coaching conversation with cached system prompt.
- * Receives conversation history + user message, returns coaching response + usage stats.
+ * Multi-turn coaching conversation. Optimized for 1-3 turns.
+ * Oura drives decisions. Strava is context. No COROS.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -16,24 +16,18 @@ interface ChatMessage {
   content: string;
 }
 
-const MAX_TURNS = 10;
+const MAX_TURNS = 5;
 
-/**
- * Build a session-history context block from recent coaching sessions.
- * Kept short — summaries preferred, full text as fallback, capped at ~600 tokens.
- */
 async function build_session_context(): Promise<string | null> {
   const sessions = await get_recent_sessions(3);
   if (sessions.length === 0) return null;
 
-  const lines: string[] = ['RECENT COACHING SESSIONS (for continuity — do not repeat advice already given):'];
+  const lines: string[] = ['Recent sessions (for continuity — do not repeat advice already given):'];
   for (const s of sessions) {
     const date = new Date(s.date * 86400000).toISOString().split('T')[0];
     const text = s.advice_summary || s.advice_full;
-    // Truncate to ~200 chars per session to stay within budget
-    const truncated = text.length > 200 ? text.slice(0, 200) + '...' : text;
-    lines.push(`\n[${date}] (${s.conversation_turns} turns):`);
-    lines.push(truncated);
+    const truncated = text.length > 300 ? text.slice(0, 300) + '...' : text;
+    lines.push(`\n[${date}]: ${truncated}`);
   }
   return lines.join('\n');
 }
@@ -61,21 +55,30 @@ export async function POST(request: NextRequest) {
     }
 
     const history = Array.isArray(conversation_history) ? conversation_history : [];
+    const turn_number = Math.floor(history.length / 2) + 1;
 
     if (history.length >= MAX_TURNS * 2) {
       return NextResponse.json(
-        { error: 'Maximum conversation length reached. Please finalize your session.' },
+        { error: 'Maximum conversation length reached. Please save your session.' },
         { status: 400 }
       );
     }
 
-    // Fetch session history only on first message (no prior conversation)
+    // Fetch session history only on first message
     const session_context = history.length === 0 ? await build_session_context() : null;
+
+    // Build turn-aware prompt suffix
+    let turn_hint = '';
+    if (turn_number === 2) {
+      turn_hint = '\n\n(This is turn 2. The user is clarifying. Be direct and wrap up unless they have more.)';
+    } else if (turn_number >= 3) {
+      turn_hint = '\n\n(This is turn 3+. Wrap up concisely. One last thing if important, then done.)';
+    }
 
     const system_blocks: Anthropic.TextBlockParam[] = [
       {
         type: 'text',
-        text: COACHING_SYSTEM_PROMPT,
+        text: COACHING_SYSTEM_PROMPT + turn_hint,
         cache_control: { type: 'ephemeral' },
       },
     ];
@@ -96,7 +99,7 @@ export async function POST(request: NextRequest) {
 
     const response = await client.messages.create({
       model: MODELS.COACHING_DAILY,
-      max_tokens: 1024,
+      max_tokens: 800,
       system: system_blocks,
       messages,
     });
@@ -108,6 +111,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       response: content.text,
+      turn: turn_number,
       usage: {
         input_tokens: response.usage.input_tokens,
         output_tokens: response.usage.output_tokens,

--- a/src/app/api/coaching/finalize/route.ts
+++ b/src/app/api/coaching/finalize/route.ts
@@ -1,12 +1,35 @@
 /**
  * API route: POST /api/coaching/finalize
- * Saves the coaching session's final advice to coaching_history.
- * Optionally generates a compressed summary via Haiku for long-term storage.
+ * Saves coaching session with auto-generated summary.
+ * Stores: full conversation, summary, daily metrics.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
+import Anthropic from '@anthropic-ai/sdk';
+import { MODELS } from '@/lib/models';
 import { save_coaching_session, populate_daily_metrics } from '@/lib/coaching/db';
+
+async function generate_summary(conversation: string): Promise<string | null> {
+  const api_key = process.env.ANTHROPIC_API_KEY;
+  if (!api_key) return null;
+
+  try {
+    const client = new Anthropic({ apiKey: api_key });
+    const response = await client.messages.create({
+      model: MODELS.COACHING_REFINE,
+      max_tokens: 200,
+      messages: [{
+        role: 'user',
+        content: `Summarize this coaching session in 2-3 sentences. Focus on: what was the main advice, any flags raised, and what was prescribed for today. No preamble.\n\n${conversation}`,
+      }],
+    });
+    const content = response.content[0];
+    return content.type === 'text' ? content.text : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: NextRequest) {
   const token = await getToken({ req: request });
@@ -16,33 +39,40 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { date, date_str, advice_full, advice_summary, conversation_turns, token_count, manual } = body as {
+    const { date, date_str, advice_full, conversation_turns, token_count, manual, data_snapshot } = body as {
       date: number;
       date_str: string;
       advice_full: string;
-      advice_summary?: string;
       conversation_turns: number;
       token_count: number;
       manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string };
+      data_snapshot?: string;
     };
 
     if (!date || !advice_full) {
       return NextResponse.json({ error: 'date and advice_full are required' }, { status: 400 });
     }
 
-    // Save coaching session and populate daily_metrics in parallel
-    await Promise.all([
-      save_coaching_session({
-        date,
-        advice_full,
-        advice_summary: advice_summary ?? null,
-        conversation_turns,
-        token_count,
-      }),
+    // Generate summary and save in parallel
+    const [summary] = await Promise.all([
+      generate_summary(advice_full),
       date_str ? populate_daily_metrics(date_str, date, manual) : Promise.resolve(),
     ]);
 
-    return NextResponse.json({ ok: true });
+    // Prepend data snapshot to full advice if provided
+    const full_with_context = data_snapshot
+      ? `[Data for this session]\n${data_snapshot}\n\n[Conversation]\n${advice_full}`
+      : advice_full;
+
+    await save_coaching_session({
+      date,
+      advice_full: full_with_context,
+      advice_summary: summary,
+      conversation_turns,
+      token_count,
+    });
+
+    return NextResponse.json({ ok: true, summary });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Finalize failed' },

--- a/src/app/api/coaching/inject/route.ts
+++ b/src/app/api/coaching/inject/route.ts
@@ -1,7 +1,7 @@
 /**
  * API route: POST /api/coaching/inject
- * Builds the data injection string from Oura + COROS + manual inputs.
- * Called by /coach page before starting a chat session.
+ * Builds the data injection string from Oura + Strava + manual inputs.
+ * No COROS. Called by /coach page before starting a chat session.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -16,21 +16,23 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { date_str, epoch_day, manual, oura_live, coros_live } = body as {
+    const { date_str, epoch_day, manual, oura_live, strava_activities } = body as {
       date_str: string;
       epoch_day: number;
       manual: ManualInputs;
       oura_live?: Record<string, unknown>;
-      coros_live?: Record<string, unknown>;
+      strava_activities?: Record<string, unknown>[];
     };
 
     if (!date_str || !epoch_day) {
       return NextResponse.json({ error: 'date_str and epoch_day are required' }, { status: 400 });
     }
 
-    const injection = await build_data_injection(date_str, epoch_day, manual || {}, oura_live, coros_live);
+    const { injection, metrics } = await build_data_injection(
+      date_str, epoch_day, manual || {}, oura_live, strava_activities
+    );
 
-    return NextResponse.json({ injection });
+    return NextResponse.json({ injection, metrics });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Injection build failed' },

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -1,6 +1,8 @@
 /**
  * /coach — Daily AI Health Coaching
- * Manual inputs + data review + multi-turn coaching chat + finalize
+ * Pre-chat: key metrics display + manual inputs
+ * Chat: clean 1-3 turn coaching conversation
+ * History: summary + expandable full conversation
  */
 
 'use client';
@@ -13,11 +15,29 @@ interface ChatMessage {
   content: string;
 }
 
-interface UsageStats {
-  input_tokens: number;
-  output_tokens: number;
-  cache_creation_input_tokens: number;
-  cache_read_input_tokens: number;
+interface Metrics {
+  readiness?: number | null;
+  hrv?: number | null;
+  resting_hr?: number | null;
+  spo2?: number | null;
+  sleep_score?: number | null;
+  sleep_total?: number | null;
+  deep_sleep_min?: number | null;
+  sleep_efficiency?: number | null;
+  cv_age?: number | null;
+  stress_min?: number | null;
+  restored_min?: number | null;
+  weight?: number | null;
+  weight_stale?: boolean;
+  back_pain?: number | null;
+  yesterday_activities?: {
+    name?: string;
+    type?: string;
+    distance?: number;
+    moving_time?: number;
+    total_elevation_gain?: number;
+    average_heartrate?: number;
+  }[];
 }
 
 interface HistorySession {
@@ -25,6 +45,31 @@ interface HistorySession {
   advice_full: string;
   advice_summary: string | null;
   conversation_turns: number;
+}
+
+function MetricCard({ label, value, unit, warn }: { label: string; value: unknown; unit?: string; warn?: boolean }) {
+  if (value === null || value === undefined) return null;
+  return (
+    <div className={`bg-zinc-900 border ${warn ? 'border-yellow-600' : 'border-zinc-800'} rounded-lg px-3 py-2`}>
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-lg font-semibold text-white">{String(value)}{unit && <span className="text-sm text-gray-400 ml-0.5">{unit}</span>}</div>
+    </div>
+  );
+}
+
+function ActivityRow({ activity }: { activity: Metrics['yesterday_activities'] extends (infer T)[] | undefined ? T : never }) {
+  const dist = activity.distance ? `${(activity.distance / 1609.34).toFixed(1)}mi` : '';
+  const elev = activity.total_elevation_gain ? `${Math.round(activity.total_elevation_gain * 3.281)}ft` : '';
+  const time = activity.moving_time ? `${Math.round(activity.moving_time / 60)}min` : '';
+  const hr = activity.average_heartrate ? `HR ${Math.round(activity.average_heartrate)}` : '';
+  const parts = [dist, elev, time, hr].filter(Boolean).join(' · ');
+  return (
+    <div className="text-sm text-gray-300">
+      <span className="text-white">{activity.name || 'Activity'}</span>
+      <span className="text-gray-500 ml-1">({activity.type})</span>
+      {parts && <span className="text-gray-400 ml-2">{parts}</span>}
+    </div>
+  );
 }
 
 export default function CoachPage() {
@@ -36,6 +81,11 @@ export default function CoachPage() {
   const [backNotes, setBackNotes] = useState('');
   const [bowel, setBowel] = useState('');
   const [injuries, setInjuries] = useState('');
+
+  // Data state
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [metricsLoading, setMetricsLoading] = useState(true);
+  const [dataInjection, setDataInjection] = useState('');
 
   // History
   const [history, setHistory] = useState<HistorySession[]>([]);
@@ -49,46 +99,99 @@ export default function CoachPage() {
   const [error, setError] = useState('');
   const [sessionStarted, setSessionStarted] = useState(false);
   const [finalized, setFinalized] = useState(false);
+  const [savedSummary, setSavedSummary] = useState('');
   const [totalTokens, setTotalTokens] = useState(0);
+  const [turnCount, setTurnCount] = useState(0);
   const chatEndRef = useRef<HTMLDivElement>(null);
+
+  const today = new Date();
+  const dateStr = today.toLocaleDateString('en-CA');
+  const epochDay = Math.floor(Date.now() / 86400000);
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const today = new Date();
-  const dateStr = today.toLocaleDateString('en-CA'); // YYYY-MM-DD
-  const epochDay = Math.floor(Date.now() / 86400000);
+  // Load metrics on mount (Oura + Strava, no manual yet)
+  useEffect(() => {
+    async function loadMetrics() {
+      try {
+        // Fetch Oura and Strava in parallel
+        const [ouraRes, stravaRes] = await Promise.all([
+          fetch(`/api/oura/data?date=${dateStr}`).catch(() => null),
+          fetch('/api/strava/data').catch(() => null),
+        ]);
+
+        const ouraData = ouraRes?.ok ? await ouraRes.json() : null;
+        const stravaData = stravaRes?.ok ? await stravaRes.json() : null;
+
+        // Build a preview injection to get metrics
+        const yesterday = new Date(today);
+        yesterday.setDate(yesterday.getDate() - 1);
+        const yesterdayStr = yesterday.toLocaleDateString('en-CA');
+
+        // Extract yesterday's activities from Strava
+        const stravaActivities = stravaData?.activities?.filter(
+          (a: { start_date_local?: string }) => a.start_date_local?.startsWith(yesterdayStr)
+        ) || [];
+
+        // Quick metrics extraction from Oura data
+        const m: Metrics = {};
+        if (ouraData?.success) {
+          const scores = ouraData.scores || {};
+          m.readiness = scores.readiness ?? null;
+          m.hrv = scores.hrv_average ?? null;
+          m.resting_hr = scores.resting_hr ?? null;
+          m.spo2 = scores.spo2_average ?? null;
+          m.sleep_score = scores.sleep ?? null;
+
+          const sleep = ouraData.daily_sleep;
+          if (sleep) {
+            m.sleep_total = sleep.total_sleep_duration ? Math.round(sleep.total_sleep_duration / 60) : null;
+            m.deep_sleep_min = sleep.deep_sleep_duration ? Math.round(sleep.deep_sleep_duration / 60) : null;
+            m.sleep_efficiency = sleep.efficiency ?? null;
+          }
+
+          const stress = ouraData.daily_stress;
+          if (stress) {
+            m.stress_min = stress.stress_high ? Math.round(stress.stress_high / 60) : null;
+            m.restored_min = stress.recovery_high ? Math.round(stress.recovery_high / 60) : null;
+          }
+        }
+
+        if (stravaActivities.length > 0) {
+          m.yesterday_activities = stravaActivities.slice(0, 5).map((a: Record<string, unknown>) => ({
+            name: a.name, type: a.sport_type || a.type,
+            distance: a.distance as number, moving_time: a.moving_time as number,
+            total_elevation_gain: a.total_elevation_gain as number,
+            average_heartrate: a.average_heartrate as number,
+          }));
+        }
+
+        setMetrics(m);
+      } catch {
+        // Best effort — metrics pane just won't show
+      } finally {
+        setMetricsLoading(false);
+      }
+    }
+    loadMetrics();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function startSession() {
     setLoading(true);
     setError('');
 
     try {
-      // Fetch live Oura data (cache doesn't store today's data)
-      let oura_snapshot = null;
-      try {
-        const ouraRes = await fetch(`/api/oura/data?date=${dateStr}`);
-        if (ouraRes.ok) {
-          const ouraData = await ouraRes.json();
-          if (ouraData.success) oura_snapshot = ouraData;
-        }
-      } catch { /* Oura fetch is best-effort */ }
+      // Fetch live data
+      const [ouraRes, stravaRes] = await Promise.all([
+        fetch(`/api/oura/data?date=${dateStr}`).catch(() => null),
+        fetch('/api/strava/data').catch(() => null),
+      ]);
 
-      // Fetch COROS data (try today, fall back to yesterday)
-      let coros_snapshot = null;
-      try {
-        const corosRes = await fetch(`/api/coros/data?date=${dateStr}`);
-        if (corosRes.ok) {
-          coros_snapshot = await corosRes.json();
-        } else {
-          const y = new Date(today);
-          y.setDate(y.getDate() - 1);
-          const yStr = y.toLocaleDateString('en-CA');
-          const corosY = await fetch(`/api/coros/data?date=${yStr}`);
-          if (corosY.ok) coros_snapshot = await corosY.json();
-        }
-      } catch { /* COROS fetch is best-effort */ }
+      const ouraData = ouraRes?.ok ? await ouraRes.json() : null;
+      const stravaData = stravaRes?.ok ? await stravaRes.json() : null;
 
       // Build data injection on the server
       const injectRes = await fetch('/api/coaching/inject', {
@@ -104,13 +207,19 @@ export default function CoachPage() {
             bowel_status: bowel || undefined,
             injury_notes: injuries || undefined,
           },
-          oura_live: oura_snapshot,
-          coros_live: coros_snapshot,
+          oura_live: ouraData?.success ? ouraData : undefined,
+          strava_activities: stravaData?.activities || undefined,
         }),
       });
 
       if (!injectRes.ok) throw new Error('Failed to build health data');
-      const { injection } = await injectRes.json();
+      const { injection, metrics: serverMetrics } = await injectRes.json();
+      setDataInjection(injection);
+
+      // Update metrics with server-computed values (includes weight trend)
+      if (serverMetrics) {
+        setMetrics(prev => ({ ...prev, ...serverMetrics, weight: weight ? parseFloat(weight) : prev?.weight }));
+      }
 
       // Send to coaching chat
       const chatRes = await fetch('/api/coaching/chat', {
@@ -128,8 +237,8 @@ export default function CoachPage() {
       }
 
       const data = await chatRes.json();
-      const usage = data.usage as UsageStats;
-      setTotalTokens(usage.input_tokens + usage.output_tokens);
+      setTotalTokens((data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0));
+      setTurnCount(1);
 
       setMessages([
         { role: 'user', content: injection },
@@ -170,9 +279,8 @@ export default function CoachPage() {
       }
 
       const data = await res.json();
-      const usage = data.usage as UsageStats;
-      setTotalTokens(prev => prev + usage.input_tokens + usage.output_tokens);
-
+      setTotalTokens(prev => prev + (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0));
+      setTurnCount(data.turn || turnCount + 1);
       setMessages([...newMessages, { role: 'assistant', content: data.response }]);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to send message');
@@ -181,16 +289,14 @@ export default function CoachPage() {
     }
   }
 
-  async function finalizeSession() {
+  async function saveSession() {
     setLoading(true);
     setError('');
 
     try {
-      // Combine all assistant responses as the full advice
       const adviceFull = messages
-        .filter(m => m.role === 'assistant')
-        .map(m => m.content)
-        .join('\n\n---\n\n');
+        .map(m => `${m.role === 'assistant' ? 'Coach' : 'You'}: ${m.content}`)
+        .join('\n\n');
 
       const res = await fetch('/api/coaching/finalize', {
         method: 'POST',
@@ -199,8 +305,9 @@ export default function CoachPage() {
           date: epochDay,
           date_str: dateStr,
           advice_full: adviceFull,
-          conversation_turns: Math.floor(messages.length / 2),
+          conversation_turns: turnCount,
           token_count: totalTokens,
+          data_snapshot: dataInjection,
           manual: {
             weight_lbs: weight ? parseFloat(weight) : undefined,
             back_pain_scale: backPain,
@@ -213,12 +320,14 @@ export default function CoachPage() {
 
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(err.error || 'Finalize failed');
+        throw new Error(err.error || 'Save failed');
       }
 
+      const data = await res.json();
       setFinalized(true);
+      setSavedSummary(data.summary || '');
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to finalize');
+      setError(e instanceof Error ? e.message : 'Failed to save');
     } finally {
       setLoading(false);
     }
@@ -244,110 +353,141 @@ export default function CoachPage() {
     return new Date(epoch * 86400000).toISOString().split('T')[0];
   }
 
+  function formatMinutes(min: number | null | undefined): string {
+    if (!min) return '—';
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  }
+
   return (
     <main className="min-h-screen bg-black text-white">
       <NavTabs />
       <div className="max-w-2xl mx-auto px-4 py-6">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold">Daily Coach</h1>
-          <button
-            onClick={loadHistory}
-            className="text-sm text-gray-400 hover:text-white border border-zinc-700 px-3 py-1 rounded transition-colors"
-          >
-            {showHistory ? 'Hide History' : 'Past Sessions'}
-          </button>
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-xl font-bold">Coach</h1>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-gray-500">{dateStr}</span>
+            <button
+              onClick={loadHistory}
+              className="text-sm text-gray-400 hover:text-white border border-zinc-700 px-3 py-1 rounded transition-colors"
+            >
+              {showHistory ? 'Hide' : 'History'}
+            </button>
+          </div>
         </div>
 
-        {showHistory && history.length > 0 && (
-          <div className="mb-6 space-y-3">
+        {/* Past Sessions */}
+        {showHistory && (
+          <div className="mb-6 space-y-2">
+            {history.length === 0 && <p className="text-gray-500 text-sm">No past sessions.</p>}
             {history.map(s => (
               <details key={s.date} className="bg-zinc-900 border border-zinc-800 rounded">
-                <summary className="px-4 py-2 cursor-pointer text-sm text-gray-300 hover:text-white">
-                  {epochDayToDate(s.date)} — {s.conversation_turns} turns
+                <summary className="px-4 py-2 cursor-pointer text-sm text-gray-300 hover:text-white flex justify-between">
+                  <span>{epochDayToDate(s.date)}</span>
+                  <span className="text-gray-500">{s.conversation_turns} turn{s.conversation_turns !== 1 ? 's' : ''}</span>
                 </summary>
-                <div className="px-4 pb-3 text-sm text-gray-400 whitespace-pre-wrap">
-                  {s.advice_summary || s.advice_full}
+                <div className="px-4 pb-3">
+                  {s.advice_summary && (
+                    <p className="text-sm text-gray-300 mb-2">{s.advice_summary}</p>
+                  )}
+                  <details className="text-xs">
+                    <summary className="text-gray-500 cursor-pointer">Full conversation</summary>
+                    <div className="mt-2 text-gray-400 whitespace-pre-wrap">{s.advice_full}</div>
+                  </details>
                 </div>
               </details>
             ))}
           </div>
         )}
 
-        {showHistory && history.length === 0 && (
-          <p className="text-gray-500 text-sm mb-6">No past sessions yet.</p>
-        )}
-
-        {!sessionStarted ? (
-          <div className="space-y-6">
-            <p className="text-gray-400 text-sm">
-              {dateStr} — Enter your manual data, then start your coaching session.
-            </p>
-
-            {/* Manual Input Form */}
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Weight (lbs)</label>
-                <input
-                  type="number"
-                  value={weight}
-                  onChange={e => setWeight(e.target.value)}
-                  placeholder="e.g. 178"
-                  className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white"
-                />
+        {/* Pre-Chat: Metrics Pane */}
+        {!sessionStarted && (
+          <div className="space-y-5">
+            {/* Metrics Grid */}
+            {metricsLoading ? (
+              <div className="text-gray-500 text-sm">Loading health data...</div>
+            ) : metrics ? (
+              <div className="space-y-3">
+                <div className="grid grid-cols-3 gap-2">
+                  <MetricCard label="Readiness" value={metrics.readiness} />
+                  <MetricCard label="HRV" value={metrics.hrv} unit="ms" />
+                  <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" />
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <MetricCard label="Sleep" value={metrics.sleep_total ? formatMinutes(metrics.sleep_total) : metrics.sleep_score} />
+                  <MetricCard label="Deep Sleep" value={metrics.deep_sleep_min ? formatMinutes(metrics.deep_sleep_min) : null} />
+                  <MetricCard label="SpO2" value={metrics.spo2} unit="%" />
+                </div>
+                {(metrics.stress_min || metrics.restored_min) && (
+                  <div className="grid grid-cols-2 gap-2">
+                    <MetricCard label="Stressed" value={metrics.stress_min} unit="min" />
+                    <MetricCard label="Restored" value={metrics.restored_min} unit="min" />
+                  </div>
+                )}
+                {metrics.yesterday_activities && metrics.yesterday_activities.length > 0 && (
+                  <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2">
+                    <div className="text-xs text-gray-500 mb-1">Yesterday&apos;s Activities</div>
+                    <div className="space-y-1">
+                      {metrics.yesterday_activities.map((a, i) => <ActivityRow key={i} activity={a} />)}
+                    </div>
+                  </div>
+                )}
               </div>
+            ) : (
+              <div className="text-gray-500 text-sm">No health data available. Oura may need to sync.</div>
+            )}
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">
-                  Back Pain: {backPain}/10
-                </label>
-                <input
-                  type="range"
-                  min="0"
-                  max="10"
-                  value={backPain}
-                  onChange={e => setBackPain(parseInt(e.target.value))}
-                  className="w-full"
-                />
-                <div className="flex justify-between text-xs text-gray-500">
-                  <span>None</span>
-                  <span>Severe</span>
+            {/* Manual Inputs */}
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Weight (lbs)</label>
+                  <input
+                    type="number"
+                    value={weight}
+                    onChange={e => setWeight(e.target.value)}
+                    placeholder="e.g. 192"
+                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Back Pain: {backPain}/10</label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="10"
+                    value={backPain}
+                    onChange={e => setBackPain(parseInt(e.target.value))}
+                    className="w-full mt-2"
+                  />
                 </div>
               </div>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Back Mobility Notes</label>
-                <input
-                  type="text"
-                  value={backNotes}
-                  onChange={e => setBackNotes(e.target.value)}
-                  placeholder="e.g. full mobility, stiff on left side"
-                  className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white"
-                />
-              </div>
-
               <details className="text-sm">
-                <summary className="text-gray-400 cursor-pointer">Optional fields</summary>
-                <div className="space-y-4 mt-3">
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Bowel Status</label>
-                    <input
-                      type="text"
-                      value={bowel}
-                      onChange={e => setBowel(e.target.value)}
-                      placeholder="e.g. normal, loose"
-                      className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Injuries / Notes</label>
-                    <textarea
-                      value={injuries}
-                      onChange={e => setInjuries(e.target.value)}
-                      placeholder="Any injuries, symptoms, or notes"
-                      rows={2}
-                      className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white"
-                    />
-                  </div>
+                <summary className="text-gray-500 cursor-pointer text-xs">More inputs</summary>
+                <div className="space-y-3 mt-2">
+                  <input
+                    type="text"
+                    value={backNotes}
+                    onChange={e => setBackNotes(e.target.value)}
+                    placeholder="Back mobility notes"
+                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                  />
+                  <input
+                    type="text"
+                    value={bowel}
+                    onChange={e => setBowel(e.target.value)}
+                    placeholder="Bowel status"
+                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                  />
+                  <textarea
+                    value={injuries}
+                    onChange={e => setInjuries(e.target.value)}
+                    placeholder="Injuries or notes for today"
+                    rows={2}
+                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                  />
                 </div>
               </details>
             </div>
@@ -359,43 +499,46 @@ export default function CoachPage() {
               disabled={loading}
               className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-zinc-700 text-white font-medium py-3 rounded transition-colors"
             >
-              {loading ? 'Loading health data...' : 'Start Coaching Session'}
+              {loading ? 'Starting...' : 'Start Session'}
             </button>
           </div>
-        ) : (
-          <div className="space-y-4">
-            {/* Chat Messages */}
-            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
-              {messages.map((msg, i) => (
+        )}
+
+        {/* Chat */}
+        {sessionStarted && (
+          <div className="space-y-3">
+            {/* Collapsed metrics summary during chat */}
+            <details className="text-xs">
+              <summary className="text-gray-500 cursor-pointer">Today&apos;s data</summary>
+              <div className="mt-1 text-gray-500 whitespace-pre-wrap bg-zinc-950 rounded p-2">{dataInjection}</div>
+            </details>
+
+            {/* Messages — skip the first user message (data injection) */}
+            <div className="space-y-3 max-h-[60vh] overflow-y-auto">
+              {messages.slice(1).map((msg, i) => (
                 <div
                   key={i}
-                  className={`text-sm whitespace-pre-wrap ${
+                  className={`text-sm rounded p-3 ${
                     msg.role === 'assistant'
-                      ? 'bg-zinc-900 border border-zinc-800 rounded p-4'
-                      : i === 0
-                        ? 'text-gray-500 bg-zinc-950 rounded p-3 text-xs'
-                        : 'text-gray-300 bg-zinc-950 rounded p-3'
+                      ? 'bg-zinc-900 border border-zinc-800 text-gray-200'
+                      : 'bg-zinc-950 text-gray-300'
                   }`}
                 >
-                  {msg.role === 'assistant' && (
-                    <span className="text-xs text-gray-500 block mb-2">Coach</span>
-                  )}
-                  {msg.content}
+                  {msg.role === 'assistant' && <span className="text-xs text-gray-500 block mb-1">Coach</span>}
+                  <div className="whitespace-pre-wrap">{msg.content}</div>
                 </div>
               ))}
               <div ref={chatEndRef} />
             </div>
 
-            {/* Input or Finalized */}
+            {/* Input or Saved */}
             {finalized ? (
-              <div className="text-center py-4">
+              <div className="text-center py-3 space-y-2">
                 <p className="text-green-400 text-sm">Session saved.</p>
-                <p className="text-gray-500 text-xs mt-1">
-                  {Math.floor(messages.length / 2)} turns, {totalTokens.toLocaleString()} tokens
-                </p>
+                {savedSummary && <p className="text-gray-400 text-xs">{savedSummary}</p>}
               </div>
             ) : (
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {error && <p className="text-red-400 text-sm">{error}</p>}
 
                 <div className="flex gap-2">
@@ -404,29 +547,29 @@ export default function CoachPage() {
                     value={input}
                     onChange={e => setInput(e.target.value)}
                     onKeyDown={e => e.key === 'Enter' && !e.shiftKey && sendMessage()}
-                    placeholder="Ask a follow-up..."
+                    placeholder={turnCount >= 3 ? 'Last chance to clarify...' : 'Ask a follow-up...'}
                     disabled={loading}
-                    className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white"
+                    className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
                   />
                   <button
                     onClick={sendMessage}
                     disabled={loading || !input.trim()}
-                    className="bg-blue-600 hover:bg-blue-700 disabled:bg-zinc-700 text-white px-4 py-2 rounded transition-colors"
+                    className="bg-zinc-700 hover:bg-zinc-600 disabled:bg-zinc-800 text-white px-4 py-2 rounded text-sm transition-colors"
                   >
                     Send
                   </button>
                 </div>
 
                 <div className="flex justify-between items-center">
-                  <span className="text-xs text-gray-500">
-                    {Math.floor(messages.length / 2)} turns, {totalTokens.toLocaleString()} tokens
+                  <span className="text-xs text-gray-600">
+                    Turn {turnCount}
                   </span>
                   <button
-                    onClick={finalizeSession}
+                    onClick={saveSession}
                     disabled={loading}
-                    className="text-sm text-gray-400 hover:text-white border border-zinc-700 px-3 py-1 rounded transition-colors"
+                    className="bg-blue-600 hover:bg-blue-700 disabled:bg-zinc-700 text-white text-sm px-4 py-1.5 rounded transition-colors"
                   >
-                    Finalize Session
+                    Save Session
                   </button>
                 </div>
               </div>

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -1,11 +1,10 @@
 /**
  * Data injection formatter for coaching sessions.
- * Pulls today's Oura + COROS data from existing Turso tables,
- * merges with trend_cache and manual inputs,
- * outputs the ~500-800 token prompt block.
+ * Pulls Oura data from wellness_cache + Strava activities + manual inputs.
+ * No COROS. Oura drives decisions. Strava is context only.
  */
 
-import { get_wellness_cache, get_coros_data } from '@/lib/db';
+import { get_wellness_cache } from '@/lib/db';
 import { get_trends, get_last_known_manual_metrics, type TrendRow } from '@/lib/coaching/db';
 
 export interface ManualInputs {
@@ -31,6 +30,25 @@ interface OuraCardiovascularAge {
   vascular_age?: number;
 }
 
+interface OuraStressDetail {
+  stress_high?: number;
+  recovery_high?: number;
+  day_summary?: string;
+}
+
+interface StravaActivity {
+  name?: string;
+  type?: string;
+  sport_type?: string;
+  start_date_local?: string;
+  distance?: number;
+  moving_time?: number;
+  total_elevation_gain?: number;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  has_heartrate?: boolean;
+}
+
 function seconds_to_hm(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
@@ -50,148 +68,6 @@ function fmt_trend(value: number | null, trends: Map<string, TrendRow>, metric: 
   return s;
 }
 
-function as_record(v: unknown): Record<string, unknown> | undefined {
-  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
-}
-
-function pick_number(obj: Record<string, unknown> | undefined, ...keys: string[]): number | undefined {
-  if (!obj) return undefined;
-  for (const k of keys) {
-    const v = obj[k];
-    if (typeof v === 'number') return v;
-    if (typeof v === 'string' && v.trim() !== '' && !isNaN(Number(v))) return Number(v);
-  }
-  return undefined;
-}
-
-function pick_string(obj: Record<string, unknown> | undefined, ...keys: string[]): string | undefined {
-  if (!obj) return undefined;
-  for (const k of keys) {
-    const v = obj[k];
-    if (typeof v === 'string' && v.trim() !== '') return v;
-    if (typeof v === 'number') return String(v);
-  }
-  return undefined;
-}
-
-function render_kv_block(label: string, obj: Record<string, unknown> | undefined, lines: string[], limit = 6): void {
-  if (!obj) return;
-  const entries = Object.entries(obj).filter(([, v]) =>
-    v !== null && v !== undefined && (typeof v === 'number' || typeof v === 'string' || typeof v === 'boolean')
-  ).slice(0, limit);
-  if (entries.length === 0) return;
-  const parts = entries.map(([k, v]) => `${k.replace(/_/g, ' ')} ${v}`);
-  lines.push(`- ${label}: ${parts.join(', ')}`);
-}
-
-function render_coros_dashboard(
-  dash: Record<string, unknown> | undefined,
-  lines: string[],
-): void {
-  if (!dash) return;
-  const ts = as_record(dash.training_status);
-  if (ts) {
-    if (ts.load_impact !== undefined) lines.push(`- Training load: Acute ${ts.load_impact}, Base Fitness ${ts.base_fitness ?? 'N/A'}`);
-    if (ts.status) lines.push(`- Training status: ${ts.status}`);
-    if (ts.intensity_trend !== undefined) lines.push(`- Intensity trend: ${ts.intensity_trend}%`);
-  }
-  const recovery = as_record(dash.recovery);
-  if (recovery) {
-    if (recovery.percentage !== undefined) lines.push(`- Recovery: ${recovery.percentage}% (${recovery.status ?? ''})`);
-    if (recovery.hours_to_full_recovery !== undefined) lines.push(`- Time to full recovery: ${recovery.hours_to_full_recovery} hrs`);
-  }
-  const hrv = as_record(dash.overnight_hrv);
-  if (hrv) {
-    if (hrv.last_night_avg) lines.push(`- Overnight HRV: ${hrv.last_night_avg}ms`);
-    if (hrv.normal_range) lines.push(`- HRV normal range: ${hrv.normal_range}`);
-  }
-  const zones = as_record(dash.threshold_hr_zones);
-  if (zones?.resting_hr_bpm) lines.push(`- Resting HR (COROS): ${zones.resting_hr_bpm} bpm`);
-  if (zones?.lactate_threshold_bpm) lines.push(`- Lactate threshold HR: ${zones.lactate_threshold_bpm} bpm`);
-  const weekly = as_record(dash.weekly_activity);
-  if (weekly?.total_distance_mi) lines.push(`- Weekly distance: ${weekly.total_distance_mi} mi`);
-  const recent = dash.recent_activities as Array<Record<string, unknown>> | undefined;
-  if (recent && recent.length > 0) {
-    const s = recent.slice(0, 3).map(a => `${a.date}: ${a.volume} (TL: ${a.training_load})`).join('; ');
-    lines.push(`- Recent activities: ${s}`);
-  }
-}
-
-function render_coros_evolab(
-  evolab: Record<string, unknown> | undefined,
-  lines: string[],
-  trends: Map<string, TrendRow>,
-): void {
-  if (!evolab) return;
-
-  // Try nested shapes first (four_week/twelve_week or 4w/12w), fall back to flat evolab.
-  const four = as_record(evolab.four_week) || as_record(evolab['4_week']) || as_record(evolab['4w']);
-  const twelve = as_record(evolab.twelve_week) || as_record(evolab['12_week']) || as_record(evolab['12w']);
-
-  const buckets: Array<[string, Record<string, unknown> | undefined]> = [
-    ['4-week', four],
-    ['12-week', twelve],
-  ];
-  let any_nested = false;
-  for (const [label, bucket] of buckets) {
-    if (!bucket) continue;
-    any_nested = true;
-    const vo2 = pick_number(bucket, 'vo2_max', 'vo2max');
-    const hrv = pick_number(bucket, 'hrv_avg', 'hrv_average', 'avg_hrv');
-    const rhr = pick_number(bucket, 'resting_hr', 'rhr', 'resting_heart_rate');
-    const parts: string[] = [];
-    if (vo2 !== undefined) parts.push(`VO2 ${vo2}`);
-    if (hrv !== undefined) parts.push(`HRV ${hrv}ms`);
-    if (rhr !== undefined) parts.push(`RHR ${rhr}bpm`);
-    if (parts.length > 0) lines.push(`- Evolab ${label}: ${parts.join(', ')}`);
-    render_kv_block(`Evolab ${label} intensity`, as_record(bucket.intensity_distribution), lines);
-    render_kv_block(`Evolab ${label} zones`, as_record(bucket.zone_distribution) || as_record(bucket.zones), lines);
-  }
-
-  if (!any_nested) {
-    // Flat evolab — pull top-level metrics.
-    const vo2 = pick_number(evolab, 'vo2_max', 'vo2max');
-    const hrv = pick_number(evolab, 'hrv_avg', 'hrv_average', 'avg_hrv');
-    const rhr = pick_number(evolab, 'resting_hr', 'rhr', 'resting_heart_rate');
-    if (vo2 !== undefined) lines.push(`- Evolab VO2 max: ${fmt_trend(vo2, trends, 'vo2_max', ' ml/kg/min')}`);
-    if (hrv !== undefined) lines.push(`- Evolab HRV avg: ${hrv}ms`);
-    if (rhr !== undefined) lines.push(`- Evolab resting HR: ${rhr} bpm`);
-    render_kv_block('Evolab intensity', as_record(evolab.intensity_distribution), lines);
-    render_kv_block('Evolab zones', as_record(evolab.zone_distribution) || as_record(evolab.zones), lines);
-  }
-}
-
-function render_coros_activities(activities: Array<Record<string, unknown>>, lines: string[]): void {
-  const cap = Math.min(activities.length, 5);
-  lines.push(`- Activities (${cap} of ${activities.length}):`);
-  for (let i = 0; i < cap; i++) {
-    const a = activities[i];
-    const title = pick_string(a, 'title', 'name') ?? 'Activity';
-    const type = pick_string(a, 'type', 'sport') ?? '';
-    const ts = pick_string(a, 'timestamp', 'date', 'start_time') ?? '';
-    const summary = pick_string(a, 'summary');
-    const eff = pick_number(a, 'efficiency');
-    const ate = pick_number(a, 'aerobic_te', 'aerobic_training_effect');
-    const nte = pick_number(a, 'anaerobic_te', 'anaerobic_training_effect');
-    const head_parts = [title, type, ts].filter(Boolean).join(' · ');
-    const tail_parts: string[] = [];
-    if (eff !== undefined) tail_parts.push(`eff ${eff}`);
-    if (ate !== undefined) tail_parts.push(`aTE ${ate}`);
-    if (nte !== undefined) tail_parts.push(`anTE ${nte}`);
-    const zones = as_record(a.zones);
-    if (zones) {
-      const ze = Object.entries(zones).filter(([, v]) => typeof v === 'number' || typeof v === 'string').slice(0, 5);
-      if (ze.length) tail_parts.push('zones ' + ze.map(([k, v]) => `${k}:${v}`).join('/'));
-    }
-    const exercises = a.exercises as Array<unknown> | undefined;
-    if (Array.isArray(exercises) && exercises.length > 0) tail_parts.push(`${exercises.length} exercises`);
-    let line = `  · ${head_parts}`;
-    if (tail_parts.length) line += ` — ${tail_parts.join(', ')}`;
-    if (summary) line += ` — ${summary.slice(0, 160)}`;
-    lines.push(line);
-  }
-}
-
 /**
  * Build the data injection string for a coaching session.
  * date_str: YYYY-MM-DD format
@@ -202,21 +78,18 @@ export async function build_data_injection(
   epoch_day: number,
   manual: ManualInputs,
   oura_live?: Record<string, unknown> | null,
-  coros_live?: Record<string, unknown> | null
-): Promise<string> {
-  // Fetch all data sources in parallel
+  strava_activities?: StravaActivity[] | null,
+): Promise<{ injection: string; metrics: Record<string, unknown> }> {
   const yesterday = new Date(date_str + 'T12:00:00');
   yesterday.setDate(yesterday.getDate() - 1);
   const yesterday_str = yesterday.toISOString().split('T')[0];
 
-  const [oura_initial, coros_initial, trend_rows, last_manual] = await Promise.all([
+  const [oura_initial, trend_rows, last_manual] = await Promise.all([
     get_wellness_cache(date_str),
-    get_coros_data(date_str),
     get_trends(epoch_day),
     get_last_known_manual_metrics(),
   ]);
   let oura = oura_initial;
-  let coros = coros_initial;
 
   // If live Oura data was passed from the client, use it over cache
   if (oura_live && oura_live.success) {
@@ -233,12 +106,12 @@ export async function build_data_injection(
       hrv_average: (scores?.hrv_average as number) ?? null,
       resting_hr: (scores?.resting_hr as number) ?? null,
       spo2_average: (scores?.spo2_average as number) ?? null,
-      steps: (scores?.steps as number) ?? null,
-      active_calories: (scores?.active_calories as number) ?? null,
+      steps: null,
+      active_calories: null,
       daily_sleep: daily_sleep ?? null,
       daily_readiness: readiness ?? null,
       daily_activity: null,
-      daily_stress: null,
+      daily_stress: oura_live.daily_stress ?? null,
       daily_resilience: null,
       daily_cardiovascular_age: null,
       daily_spo2: null,
@@ -252,25 +125,9 @@ export async function build_data_injection(
     };
   }
 
-  // If live COROS data was passed from the client, use it over cache
-  if (coros_live && coros_live.data) {
-    coros = {
-      date: (coros_live.date as string) ?? date_str,
-      data: coros_live.data,
-      source: 'live',
-      created_at: '',
-      updated_at: '',
-    };
-  }
-
-  // Fall back to yesterday's cached data if still empty
-  if (!oura || !coros) {
-    const [oura_y, coros_y] = await Promise.all([
-      !oura ? get_wellness_cache(yesterday_str) : Promise.resolve(oura),
-      !coros ? get_coros_data(yesterday_str) : Promise.resolve(coros),
-    ]);
-    oura = oura_y;
-    coros = coros_y;
+  // Fall back to yesterday's cached data if today's isn't available
+  if (!oura) {
+    oura = await get_wellness_cache(yesterday_str);
   }
 
   const trends = new Map<string, TrendRow>();
@@ -278,119 +135,131 @@ export async function build_data_injection(
     trends.set(row.metric_name, row);
   }
 
+  // Build metrics object for pre-chat display
+  const metrics: Record<string, unknown> = {};
   const lines: string[] = [];
-  lines.push(`Today's Health Data (${date_str}):`);
+  lines.push(`Health data for ${date_str}:`);
   lines.push('');
 
-  // --- SLEEP & RECOVERY (Oura) ---
-  const oura_label = oura?.date === yesterday_str ? `Oura — using ${yesterday_str} data` : 'Oura';
-  lines.push(`SLEEP & RECOVERY (${oura_label}):`);
+  // --- OURA ---
+  const oura_label = oura?.date === yesterday_str ? `using ${yesterday_str} data` : '';
   if (oura) {
     const sleep = oura.daily_sleep as OuraSleepDetail | null;
     const readiness = oura.daily_readiness as OuraReadinessDetail | null;
     const cv_age = oura.daily_cardiovascular_age as OuraCardiovascularAge | null;
+    const stress = oura.daily_stress as OuraStressDetail | null;
+
+    const readiness_val = readiness?.score ?? oura.readiness_score ?? null;
+    const hrv_val = oura.hrv_average ?? null;
+    const rhr_val = oura.resting_hr ?? null;
+    const spo2_val = oura.spo2_average ?? null;
+
+    metrics.readiness = readiness_val;
+    metrics.hrv = hrv_val;
+    metrics.resting_hr = rhr_val;
+    metrics.spo2 = spo2_val;
+    metrics.sleep_score = oura.sleep_score;
+
+    if (oura_label) lines.push(`(Oura ${oura_label})`);
+    lines.push(`Readiness: ${readiness_val ?? 'N/A'}/100`);
+    lines.push(`HRV: ${fmt_trend(hrv_val, trends, 'hrv_rmssd', 'ms')}`);
+    lines.push(`Resting HR: ${fmt_trend(rhr_val, trends, 'resting_hr', ' bpm')}`);
 
     if (sleep) {
-      const duration = sleep.total_sleep_duration ? seconds_to_hm(sleep.total_sleep_duration) : 'N/A';
-      const efficiency = sleep.efficiency ? `${sleep.efficiency}%` : 'N/A';
+      const total = sleep.total_sleep_duration ? seconds_to_hm(sleep.total_sleep_duration) : 'N/A';
       const deep = sleep.deep_sleep_duration ? seconds_to_hm(sleep.deep_sleep_duration) : 'N/A';
-      const rem = sleep.rem_sleep_duration ? seconds_to_hm(sleep.rem_sleep_duration) : 'N/A';
-      lines.push(`- Sleep: ${duration} (efficiency ${efficiency}, deep ${deep}, REM ${rem})`);
-    } else {
-      lines.push(`- Sleep score: ${oura.sleep_score ?? 'N/A'}`);
+      const deep_min = sleep.deep_sleep_duration ? Math.round(sleep.deep_sleep_duration / 60) : null;
+      const efficiency = sleep.efficiency ? `${sleep.efficiency}%` : 'N/A';
+      lines.push(`Sleep: ${total} total, ${deep} deep, efficiency ${efficiency}`);
+      metrics.sleep_total = sleep.total_sleep_duration ? Math.round(sleep.total_sleep_duration / 60) : null;
+      metrics.deep_sleep_min = deep_min;
+      metrics.sleep_efficiency = sleep.efficiency ?? null;
+    } else if (oura.sleep_score) {
+      lines.push(`Sleep score: ${oura.sleep_score}`);
     }
 
-    lines.push(`- HRV: ${fmt_trend(oura.hrv_average, trends, 'hrv_rmssd', 'ms')}`);
-    lines.push(`- Resting HR: ${fmt_trend(oura.resting_hr, trends, 'resting_hr', ' bpm')}`);
-    lines.push(`- Readiness: ${readiness?.score ?? oura.readiness_score ?? 'N/A'}/100`);
+    if (spo2_val) {
+      lines.push(`SpO2: ${spo2_val}%`);
+      metrics.spo2 = spo2_val;
+    }
 
     if (cv_age?.vascular_age) {
-      lines.push(`- Cardiovascular age: ${cv_age.vascular_age}`);
+      lines.push(`Cardiovascular age: ${cv_age.vascular_age}`);
+      metrics.cv_age = cv_age.vascular_age;
+    }
+
+    if (stress) {
+      const stressed_min = stress.stress_high ? Math.round(stress.stress_high / 60) : null;
+      const restored_min = stress.recovery_high ? Math.round(stress.recovery_high / 60) : null;
+      if (stressed_min !== null || restored_min !== null) {
+        lines.push(`Stress: ${stressed_min ?? '?'}min stressed, ${restored_min ?? '?'}min restored`);
+        metrics.stress_min = stressed_min;
+        metrics.restored_min = restored_min;
+      }
     }
   } else {
-    lines.push('- No Oura data available for today');
+    lines.push('No Oura data available');
   }
 
   lines.push('');
 
-  // --- PERFORMANCE (COROS) ---
-  const coros_label = coros && (coros as { date: string }).date === yesterday_str ? `COROS — using ${yesterday_str} data` : 'COROS';
-  lines.push(`PERFORMANCE (${coros_label}):`);
-  if (coros) {
-    const d = coros.data as Record<string, unknown>;
-    const before = lines.length;
+  // --- STRAVA ACTIVITIES (yesterday) ---
+  if (strava_activities && strava_activities.length > 0) {
+    // Filter to yesterday's activities
+    const yesterday_activities = strava_activities.filter(a => {
+      if (!a.start_date_local) return false;
+      return a.start_date_local.startsWith(yesterday_str);
+    });
 
-    // Dashboard (Chrome extension Training Hub scrape)
-    render_coros_dashboard(d.dashboard as Record<string, unknown> | undefined, lines);
-
-    // Evolab (multi-week training metrics: VO2 max, HRV, RHR, zone/intensity distributions)
-    render_coros_evolab(d.evolab as Record<string, unknown> | undefined, lines, trends);
-
-    // Activities (per-activity detail: title, type, timestamp, summary, zones, TE)
-    const activities = d.activities as Array<Record<string, unknown>> | undefined;
-    if (activities && activities.length > 0) {
-      render_coros_activities(activities, lines);
-    }
-
-    // Flat fallback for older data shapes
-    if (!d.dashboard && !d.evolab && !activities) {
-      if (d.vo2_max !== undefined) lines.push(`- VO2 max: ${fmt_trend(Number(d.vo2_max), trends, 'vo2_max', ' ml/kg/min')}`);
-      if (d.recovery !== undefined) lines.push(`- Recovery: ${d.recovery}%`);
-      if (d.training_load !== undefined) lines.push(`- Training load: ${d.training_load}`);
-    }
-
-    // Report markdown: included only if structured rendering produced nothing,
-    // or appended as a trimmed narrative if present. Keeps token budget bounded.
-    const report_md = typeof d.report_markdown === 'string' ? (d.report_markdown as string) : '';
-    if (report_md) {
-      const wrote_structured = lines.length > before;
-      const budget = wrote_structured ? 1200 : 2500;
-      const trimmed = report_md.length > budget ? report_md.slice(0, budget) + '…(truncated)' : report_md;
-      lines.push('');
-      lines.push('COROS briefing:');
-      lines.push(trimmed);
-    }
-
-    if (lines.length === before) {
-      lines.push('- COROS data present but no recognised fields');
+    if (yesterday_activities.length > 0) {
+      lines.push(`Yesterday's activities (${yesterday_str}):`);
+      metrics.yesterday_activities = [];
+      for (const a of yesterday_activities.slice(0, 5)) {
+        const name = a.name || 'Activity';
+        const type = a.sport_type || a.type || '';
+        const dist = a.distance ? `${(a.distance / 1609.34).toFixed(1)}mi` : '';
+        const elev = a.total_elevation_gain ? `${Math.round(a.total_elevation_gain * 3.281)}ft elev` : '';
+        const time = a.moving_time ? `${Math.round(a.moving_time / 60)}min` : '';
+        const hr = a.average_heartrate ? `avg HR ${Math.round(a.average_heartrate)}` : '';
+        const parts = [type, dist, elev, time, hr].filter(Boolean).join(', ');
+        lines.push(`- ${name}: ${parts}`);
+        (metrics.yesterday_activities as StravaActivity[]).push({
+          name, type, distance: a.distance, moving_time: a.moving_time,
+          total_elevation_gain: a.total_elevation_gain,
+          average_heartrate: a.average_heartrate, max_heartrate: a.max_heartrate,
+        });
+      }
+    } else {
+      lines.push('No activities recorded yesterday');
     }
   } else {
-    lines.push('- No COROS data available for today');
+    lines.push('No Strava data available');
   }
 
   lines.push('');
 
-  // --- BODY COMPOSITION (Manual) ---
-  lines.push('BODY COMPOSITION (Manual):');
+  // --- WEIGHT & MANUAL ---
   if (manual.weight_lbs !== undefined) {
-    lines.push(`- Weight: ${fmt_trend(manual.weight_lbs, trends, 'weight_lbs', ' lbs')}`);
+    lines.push(`Weight: ${fmt_trend(manual.weight_lbs, trends, 'weight_lbs', ' lbs')}`);
+    metrics.weight = manual.weight_lbs;
   } else if (last_manual.weight_lbs !== null && last_manual.weight_date !== null) {
-    const weight_date_str = new Date(last_manual.weight_date * 86400000).toISOString().split('T')[0];
-    lines.push(`- Weight: ${fmt_trend(last_manual.weight_lbs, trends, 'weight_lbs', ' lbs')} (last entered ${weight_date_str})`);
-  } else {
-    lines.push('- Weight: not entered');
+    const d = new Date(last_manual.weight_date * 86400000).toISOString().split('T')[0];
+    lines.push(`Weight: ${last_manual.weight_lbs} lbs (last entered ${d})`);
+    metrics.weight = last_manual.weight_lbs;
+    metrics.weight_stale = true;
   }
 
   if (manual.back_pain_scale !== undefined) {
     const mobility = manual.back_mobility_notes ? `, ${manual.back_mobility_notes}` : '';
-    lines.push(`- Back status: ${manual.back_pain_scale}/10 pain${mobility}`);
-  } else if (last_manual.back_pain_scale !== null && last_manual.back_pain_date !== null) {
-    const back_date_str = new Date(last_manual.back_pain_date * 86400000).toISOString().split('T')[0];
-    lines.push(`- Back status: ${last_manual.back_pain_scale}/10 pain (last entered ${back_date_str})`);
-  } else {
-    lines.push('- Back status: not entered');
+    lines.push(`Back: ${manual.back_pain_scale}/10${mobility}`);
+    metrics.back_pain = manual.back_pain_scale;
   }
 
-  if (manual.bowel_status) {
-    lines.push(`- Bowel: ${manual.bowel_status}`);
-  }
-
-  if (manual.injury_notes) {
-    lines.push(`- Injuries/notes: ${manual.injury_notes}`);
-  }
+  if (manual.bowel_status) lines.push(`Bowel: ${manual.bowel_status}`);
+  if (manual.injury_notes) lines.push(`Notes: ${manual.injury_notes}`);
 
   lines.push('');
-  lines.push('What coaching advice do you have for me today?');
+  lines.push('Coach me.');
 
-  return lines.join('\n');
+  return { injection: lines.join('\n'), metrics };
 }

--- a/src/lib/coaching/system-prompt.ts
+++ b/src/lib/coaching/system-prompt.ts
@@ -1,76 +1,52 @@
-// Coach system prompt — distilled from the Longevity Performance Framework
-// and Biomarkers of Aging Research. See MASTER_STATE_OF_KNOWLEDGE.md for full context.
-// Target: ~2,000 tokens. Cached via cache_control: {"type": "ephemeral"}.
+// Coaching system prompt — 99-Year-Old Athlete framework
+// Oura drives decisions. Strava provides activity context. No COROS.
+// Target: ~1,500 tokens. Cached via cache_control: {"type": "ephemeral"}.
 
-export const COACHING_SYSTEM_PROMPT = `You are a daily health and performance coach for a single user. Your framework is the 90-Year-Old Athlete model: bank enough physiological reserve now so decades of age-related decline still leave the user performing at a level most people half their age cannot match. Not surviving. Performing.
+export const COACHING_SYSTEM_PROMPT = `You are a daily health coach for one person. Your framework: the 99-Year-Old Athlete. Bank enough physiological reserve now so decades of decline still leave him performing at a level most people half his age cannot match.
 
-## Protocol Hierarchy (highest to lowest — NEVER skip a level)
+## How You Coach
 
-1. AUTONOMIC CRISIS OVERRIDE — If the user is in emotional/neurological dysregulation crisis, restore bike ACCESS immediately on maximum e-bike assist. Cycling is neurological regulation, not optional exercise. This supersedes ALL other protocols including Red Back containment. Never remove the bike option during a crisis. If Symptom Gates (vertigo, lightheadedness) are concurrent, present the bike as one option alongside lower-fall-risk alternatives (stationary bike, supported walk). Do not block it. Do not hide the risk. Preserving autonomy during crisis is therapeutic; removing it worsens dysregulation.
-2. SYMPTOM GATES — Vertigo, standing lightheadedness, or active red back (7+/10) override all readiness scores and training prescriptions. When active without a concurrent crisis, these gates constrain activity directly.
-3. DAY CLASSIFICATION — Green / Yellow / Red, derived from dual-lens sensor data below.
-4. TRAINING PRESCRIPTION — Issued only after levels 1-3 are resolved.
+You are a trusted coach who knows this person. Speak directly. Say what matters, skip what he already knows. No templates, no headers, no tables, no protocol checklists. Max ~200 words on your first response. If he asks a follow-up, stay concise.
 
-## Dual-Lens Sensor Model
+He may have 1 turn with you, maybe 2, rarely 3. Optimize for first-turn value. No filler. No hallucinating. If you don't know something, say so in one sentence.
 
-- Oura Ring = nervous system lens (overnight HRV trends, sleep architecture, readiness, cardiovascular age)
-- COROS Watch = mechanical/metabolic lens (training load, recovery %, acute fatigue, VO2 max, workout detail)
+## Data Sources
 
-Divergence rules:
-- Oura overnight HRV is more reliable than COROS morning spot HRV for readiness. Do not let a suppressed morning spot reading override a positive overnight trend.
-- Both devices agreeing on resting HR = high-confidence signal.
-- COROS wrist HR during cycling is unreliable (vibration/motor artifact).
-- Oura Good + COROS Fatigued = mechanical fatigue with nervous system recovery. Prescribe lighter mechanical load, not full rest.
-- ALWAYS flag device divergence explicitly. Never silently pick one.
+- **Oura Ring** = primary. Drives all coaching decisions. Readiness, HRV, resting HR, sleep (total, deep, SpO2), stress/recovery time.
+- **Strava activities** = context only. Shows what he did yesterday (type, distance, elevation, duration, avg HR). Strava HR comes from a wrist sensor on an e-MTB — it overestimates effort due to motor vibration. Treat Strava HR as approximate. If Strava says a ride was hard but Oura readiness is strong the next morning, Oura wins. Never override Oura with Strava HR data.
+- **Manual inputs** = weight, back pain, notes. Always present.
 
-## Key Protocols
+## Decision Logic
 
-Red Back Protocol — Trigger: back status 7+/10. Action: walk only, flat terrain, HR <105, no bike. Exception: Autonomic Crisis Override (Level 1).
+Read the whole picture. No rigid thresholds. Oura readiness is the starting point, modified by:
+- Sleep quality: good readiness but poor deep sleep or low SpO2 — flag it, temper the day.
+- HRV trend: if declining 3+ days, name the pattern even if today looks fine.
+- Weight trend: 3+ day sustained upward trend gets coached on directly. Not panic — actionable guidance. Never dismiss weight as "single-day noise" when a trend exists.
+- Yesterday's activity: informs recommendation. Big day yesterday + strong Oura = moderate today. Light yesterday + strong Oura = push today. But Oura's morning-after response is the truth of how his body handled it.
 
-Fasting-Safe Movement — Trigger: extended fast (3+ days). Gate: salt-and-stand test + flat walk test must pass before bike. Action: regulation riding only (high assist, Zone 1-2, nasal breathing).
+Speak plainly about the day: "you're good to push today" or "sleep was short, keep it moderate" or "rest today, here's why." No Green/Yellow/Red labels unless he finds them useful.
 
-Post-Refeed Scale Bounce — First 1-2 days after breaking multi-day fast with carbs: weight increase is water + glycogen, not fat. Evaluate weight on 7-day rolling window only.
+## Override Gates (always check first)
 
-Refeed Sequence — Shake first, one small meal, walk after. No large bolus meal as first refeed (documented abdominal pain trigger).
+- Back pain ≥7/10: walk only, flat terrain, HR <105. Exception: autonomic crisis.
+- Autonomic crisis (emotional/neurological dysregulation): bike ACCESS on maximum e-assist is neurological regulation, not optional exercise. Never remove the bike option during crisis. This supersedes back protocol.
+- Vertigo or standing lightheadedness: constrain activity, lower fall risk.
 
-Sensory Shield — When the user mentions high-noise or high-debris activities (trail building, power tools, shop work, concerts, mowing), prompt hearing and eye protection. Hearing impairment is a primary modifiable dementia risk factor (up to 94% increased risk). Early intervention matters more than treatment after decline. Annual hearing assessment after 50, vision prescription current.
+## Weight Coaching
 
-Inflammation Bridge — Wearables cannot measure inflammatory biomarkers directly. However: sustained HRV suppression + elevated RHR + poor sleep efficiency, persisting >7 days in the absence of overtraining or acute illness, may indicate systemic inflammatory load. Flag this pattern and recommend professional bloodwork (hs-CRP, IL-6). Do not diagnose — bridge to clinical evaluation. Daily targets remain: Omega-3 Index ≥8%, Vitamin D 40-60 ng/mL (both periodic blood tests, not daily).
+Weight matters for the 99-Year-Old Athlete: strength-to-weight ratio, bone/joint stress, cardiovascular risk, inflammation. Track on 7-day rolling average. When the trend is up for 3+ days, coach on it — what to consider, what to adjust. When he mentions wanting to stop eating at 195, help him distinguish a knee-jerk reaction from a real signal. Never ignore weight. Never reduce it to "noise."
 
-## The 15 Longevity Levers
+## The 15 Longevity Levers (reference, not checklist)
 
-Track and coach across these. Levers 1-5 and 10 have daily wearable data. Others are periodic, situational, or manual.
+1. VO2 max — Zone 2 work + intervals. 2. CV age / HRV / RHR. 3. Muscle mass, strength, power — sarcopenia resistance, grip strength, explosive movements. 4. Body composition. 5. Sleep quality and regularity. 6. ApoB. 7. Metabolic health. 8. Inflammation. 9. Stability, balance, injury resilience. 10. Stress regulation. 11. Sauna. 12. Cognitive health. 13. Sensory health. 14. Oral health. 15. Social connection.
 
-1. VO2 max — North star. Zone 2 (3-4x/wk, 45-60 min) + 1 VO2max interval session. Target: >75th percentile for age/sex.
-2. Cardiovascular age / HRV / resting HR — Arterial health signal. CV age below chronological. RHR 50-70 bpm. HRV tracked as trend, not absolute.
-3. Muscle mass, strength, and power — Resist sarcopenia. Compound lifts 3x/wk, progressive overload. Power (rate of force development) declines faster than strength and is the primary fall-prevention variable — include explosive movements appropriate to current status. Grip strength is a top mortality predictor.
-4. Body composition — Minimize visceral fat. Weight tracked on 7-day and 30-day rolling averages. DEXA annually.
-5. Sleep quality and regularity — Regularity is the dominant variable (stronger mortality predictor than duration). Targets: efficiency >85%, deep >1h, REM >1.5h, consistent timing ±1h.
-6. ApoB — Target <60 mg/dL. Test every 6 months. Periodic review only.
-7. Metabolic health — Fasting insulin <5 μIU/mL, glucose <90, HbA1c <5.3%. Periodic review only.
-8. Inflammation — hs-CRP <1.0. See Inflammation Bridge protocol for daily wearable proxy. Periodic bloodwork for direct measurement.
-9. Stability, balance, injury resilience — Daily mobility. Single-leg stance ≥30s. SRT ≥8/10.
-10. Stress regulation — Tracked through HRV. Sustained HRV decline despite adequate sleep = stress overload. Prescribe load reduction proactively.
-11. Sauna — 4+/wk, 15-20 min at ~80°C. Proven 40% all-cause mortality reduction.
-12. Cognitive health — Driven by aerobic exercise + sleep + novel learning. Coach indirectly through Levers 1, 5, and 15.
-13. Sensory health — See Sensory Shield protocol. Situationally coachable.
-14. Oral health — Systemic inflammatory and cardiovascular signal. Periodic review only.
-15. Social connection — 50% mortality reduction. Flag isolation patterns if detected in conversation.
+Coach across these when relevant. Don't list them. Weave them into practical advice.
 
-## Fixation Gate
+## What NOT to Do
 
-The pursuit of longevity can degrade the quality of the life it tries to extend. ~16% of health-tracking populations show orthorexic or fixation traits. Monitor for these patterns across sessions:
-
-Language triggers (primary): guilt or self-punishment over missed sessions, anxiety disproportionate to minor metric fluctuations, social withdrawal to protect dietary or sleep protocols, inability to discuss food without calculating impact, identity fusion with health metrics ("I'm failing" tied to a single bad night).
-
-Physiological triggers (secondary): sustained elevated RHR + suppressed HRV despite adequate sleep and low training load, persisting across multiple sessions. This pattern MAY indicate stress-driven cortisol elevation but could also indicate illness. Use as a prompt to check in, not to diagnose.
-
-Do not fire on a single bad day or one frustrated comment. Look for patterns across sessions. When the gate fires, name it directly: "Health is a means to a life of purpose and experience, not an end in itself."
-
-## Coaching Rules
-
-- Never assert unsupported mechanism claims. Only cite what this framework documents.
-- Track what data has been received this session. Never ask for data already submitted.
-- Read the weight log before issuing any weight summary or direction claim.
-- When issuing any restriction, check Autonomic Crisis Override FIRST.
-- The 15 levers are a coupled system, not a checklist. Improvements in one lever cascade; degradation in one lever loads the others.`;
+- Never base coaching on training load math from any device.
+- Never repeat the same recovery-day prescription every session. If he's ready to train, say so.
+- Never produce verbose daily templates with section headers.
+- Never say "single day is noise" about weight when a multi-day trend exists.
+- Never ask for eMTB assist mode details. Automatically down-weight Strava HR from rides.
+- Never hallucinate data you weren't given.`;


### PR DESCRIPTION
## Summary
- Oura Ring drives all coaching decisions. COROS removed from coaching logic entirely.
- Strava activities shown as context (yesterday's rides/walks) but HR data is treated as approximate — never overrides Oura readiness.
- Pre-chat metrics pane: readiness, HRV, RHR, sleep total, deep sleep, SpO2, stress/restored time, yesterday's activities.
- Clean chat interface optimized for 1-3 turns. No verbose templates, no protocol headers.
- Auto-generated session summaries on save. History shows summary by default, expandable to full conversation.
- Weight is coached on (trend tracking, actionable guidance) — never dismissed as "noise."

## Test plan
- [ ] Open /coach on phone, verify metrics grid loads from Oura
- [ ] Enter weight + back pain, start session — verify coach responds concisely (~200 words)
- [ ] Verify no COROS references in coaching output
- [ ] Send 1 follow-up, verify coach stays concise and wraps up
- [ ] Save session, verify summary appears
- [ ] Check History — summary visible, full conversation expandable
- [ ] Verify Strava yesterday's activities appear in pre-chat pane

Preview: https://work-claude-coaching-v2-8i11.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)