### PR TITLE
Coach metrics overhaul: recovery status, sleep durations, resilience, Strava links

### DIFF
--- a/src/app/api/coaching/finalize/route.ts
+++ b/src/app/api/coaching/finalize/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODELS } from '@/lib/models';
-import { save_coaching_session, populate_daily_metrics } from '@/lib/coaching/db';
+import { save_coaching_session, populate_daily_metrics, type InjectMetrics } from '@/lib/coaching/db';
 
 async function generate_summary(conversation: string): Promise<string | null> {
   const api_key = process.env.ANTHROPIC_API_KEY;
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { date, date_str, advice_full, conversation_turns, token_count, manual, data_snapshot } = body as {
+    const { date, date_str, advice_full, conversation_turns, token_count, manual, data_snapshot, inject_metrics } = body as {
       date: number;
       date_str: string;
       advice_full: string;
@@ -47,6 +47,7 @@ export async function POST(request: NextRequest) {
       token_count: number;
       manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string };
       data_snapshot?: string;
+      inject_metrics?: InjectMetrics;
     };
 
     if (!date || !advice_full) {
@@ -56,7 +57,7 @@ export async function POST(request: NextRequest) {
     // Generate summary and save in parallel
     const [summary] = await Promise.all([
       generate_summary(advice_full),
-      date_str ? populate_daily_metrics(date_str, date, manual) : Promise.resolve(),
+      date_str ? populate_daily_metrics(date_str, date, manual, inject_metrics) : Promise.resolve(),
     ]);
 
     // Prepend data snapshot to full advice if provided

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -23,10 +23,12 @@ interface Metrics {
   sleep_score?: number | null;
   sleep_total?: number | null;
   deep_sleep_min?: number | null;
+  rem_sleep_min?: number | null;
   sleep_efficiency?: number | null;
   cv_age?: number | null;
   stress_min?: number | null;
   restored_min?: number | null;
+  recovery_status?: string | null;
   weight?: number | null;
   weight_stale?: boolean;
   back_pain?: number | null;
@@ -149,6 +151,7 @@ export default function CoachPage() {
           if (sleep) {
             m.sleep_total = sleep.total_sleep_duration ? Math.round(sleep.total_sleep_duration / 60) : null;
             m.deep_sleep_min = sleep.deep_sleep_duration ? Math.round(sleep.deep_sleep_duration / 60) : null;
+            m.rem_sleep_min = sleep.rem_sleep_duration ? Math.round(sleep.rem_sleep_duration / 60) : null;
             m.sleep_efficiency = sleep.efficiency ?? null;
           }
 
@@ -157,6 +160,26 @@ export default function CoachPage() {
             m.stress_min = stress.stress_high ? Math.round(stress.stress_high / 60) : null;
             m.restored_min = stress.recovery_high ? Math.round(stress.recovery_high / 60) : null;
           }
+        }
+
+        // Client-side recovery estimate (upgraded by server after inject)
+        if (m.readiness !== null && m.readiness !== undefined) {
+          const deep_ok = m.deep_sleep_min ? m.deep_sleep_min >= 60 : null;
+          const sleep_ok = m.sleep_total ? m.sleep_total >= 420 : null;
+          const stress_ratio = (m.stress_min && m.restored_min)
+            ? m.restored_min / (m.stress_min + m.restored_min) : null;
+          let score = 0;
+          if (m.readiness >= 85) score += 2; else if (m.readiness >= 70) score += 1;
+          else if (m.readiness < 60) score -= 2; else score -= 1;
+          if (deep_ok === true) score += 1; if (deep_ok === false) score -= 1;
+          if (sleep_ok === true) score += 1; if (sleep_ok === false) score -= 1;
+          if (stress_ratio !== null && stress_ratio >= 0.5) score += 1;
+          if (stress_ratio !== null && stress_ratio < 0.5) score -= 1;
+          if (score >= 4) m.recovery_status = 'Ready to push';
+          else if (score >= 2) m.recovery_status = 'Ready — moderate effort';
+          else if (score >= 0) m.recovery_status = 'Easy day';
+          else if (score >= -2) m.recovery_status = 'Recovery — light movement only';
+          else m.recovery_status = 'Rest day';
         }
 
         if (stravaActivities.length > 0) {
@@ -409,22 +432,57 @@ export default function CoachPage() {
               <div className="text-gray-500 text-sm">Loading health data...</div>
             ) : metrics ? (
               <div className="space-y-3">
-                <div className="grid grid-cols-3 gap-2">
-                  <MetricCard label="Readiness" value={metrics.readiness} />
+                {/* Recovery Status — the primary signal */}
+                {metrics.recovery_status && (
+                  <div className={`border rounded-lg px-4 py-3 ${
+                    metrics.recovery_status.startsWith('Ready to push') ? 'bg-green-950 border-green-800' :
+                    metrics.recovery_status.startsWith('Ready') ? 'bg-emerald-950 border-emerald-800' :
+                    metrics.recovery_status.startsWith('Easy') ? 'bg-yellow-950 border-yellow-800' :
+                    metrics.recovery_status.startsWith('Recovery') ? 'bg-orange-950 border-orange-800' :
+                    'bg-red-950 border-red-800'
+                  }`}>
+                    <div className="text-xs text-gray-400">Today&apos;s Status</div>
+                    <div className="text-lg font-semibold text-white">{metrics.recovery_status}</div>
+                  </div>
+                )}
+
+                {/* Sleep — actual durations */}
+                <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2">
+                  <div className="text-xs text-gray-500 mb-1">Sleep</div>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div>
+                      <div className="text-lg font-semibold text-white">{metrics.sleep_total ? formatMinutes(metrics.sleep_total) : '—'}</div>
+                      <div className="text-xs text-gray-500">total</div>
+                    </div>
+                    <div>
+                      <div className="text-lg font-semibold text-white">{metrics.deep_sleep_min ? formatMinutes(metrics.deep_sleep_min) : '—'}</div>
+                      <div className="text-xs text-gray-500">deep</div>
+                    </div>
+                    <div>
+                      <div className="text-lg font-semibold text-white">{metrics.rem_sleep_min ? formatMinutes(metrics.rem_sleep_min) : '—'}</div>
+                      <div className="text-xs text-gray-500">REM</div>
+                    </div>
+                  </div>
+                  {metrics.spo2 && (
+                    <div className="mt-1 text-xs text-gray-500">Blood oxygen: {Math.round(metrics.spo2)}%</div>
+                  )}
+                </div>
+
+                {/* Physiology row */}
+                <div className="grid grid-cols-2 gap-2">
                   <MetricCard label="HRV" value={metrics.hrv} unit="ms" />
                   <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" />
                 </div>
-                <div className="grid grid-cols-3 gap-2">
-                  <MetricCard label="Sleep" value={metrics.sleep_total ? formatMinutes(metrics.sleep_total) : metrics.sleep_score} />
-                  <MetricCard label="Deep Sleep" value={metrics.deep_sleep_min ? formatMinutes(metrics.deep_sleep_min) : null} />
-                  <MetricCard label="SpO2" value={metrics.spo2} unit="%" />
-                </div>
+
+                {/* Stress/Recovery */}
                 {(metrics.stress_min || metrics.restored_min) && (
                   <div className="grid grid-cols-2 gap-2">
                     <MetricCard label="Stressed" value={metrics.stress_min} unit="min" />
                     <MetricCard label="Restored" value={metrics.restored_min} unit="min" />
                   </div>
                 )}
+
+                {/* Yesterday's Activities */}
                 {metrics.yesterday_activities && metrics.yesterday_activities.length > 0 && (
                   <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2">
                     <div className="text-xs text-gray-500 mb-1">Yesterday&apos;s Activities</div>

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -29,6 +29,8 @@ interface Metrics {
   stress_min?: number | null;
   restored_min?: number | null;
   recovery_status?: string | null;
+  resilience?: string | null;
+  resilience_pct?: number | null;
   weight?: number | null;
   weight_stale?: boolean;
   back_pain?: number | null;
@@ -159,6 +161,18 @@ export default function CoachPage() {
           if (stress) {
             m.stress_min = stress.stress_high ? Math.round(stress.stress_high / 60) : null;
             m.restored_min = stress.recovery_high ? Math.round(stress.recovery_high / 60) : null;
+            // Client-side resilience from today's stress/recovery
+            if (m.stress_min && m.restored_min) {
+              const total = m.stress_min + m.restored_min;
+              if (total > 0) {
+                const pct = Math.round((m.restored_min / total) * 100);
+                m.resilience_pct = pct;
+                if (pct >= 65) m.resilience = 'High recovery, low stress';
+                else if (pct >= 50) m.resilience = 'Balanced';
+                else if (pct >= 35) m.resilience = 'Elevated stress';
+                else m.resilience = 'High stress, low recovery';
+              }
+            }
           }
         }
 
@@ -338,6 +352,18 @@ export default function CoachPage() {
             bowel_status: bowel || undefined,
             injury_notes: injuries || undefined,
           },
+          inject_metrics: metrics ? {
+            readiness: metrics.readiness,
+            hrv: metrics.hrv,
+            resting_hr: metrics.resting_hr,
+            spo2: metrics.spo2,
+            sleep_total: metrics.sleep_total,
+            deep_sleep_min: metrics.deep_sleep_min,
+            rem_sleep_min: metrics.rem_sleep_min,
+            sleep_efficiency: metrics.sleep_efficiency,
+            stress_min: metrics.stress_min,
+            restored_min: metrics.restored_min,
+          } : undefined,
         }),
       });
 
@@ -474,11 +500,26 @@ export default function CoachPage() {
                   <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" />
                 </div>
 
-                {/* Stress/Recovery */}
+                {/* Resilience / Stress-Recovery */}
                 {(metrics.stress_min || metrics.restored_min) && (
-                  <div className="grid grid-cols-2 gap-2">
-                    <MetricCard label="Stressed" value={metrics.stress_min} unit="min" />
-                    <MetricCard label="Restored" value={metrics.restored_min} unit="min" />
+                  <div className={`bg-zinc-900 border rounded-lg px-3 py-2 ${
+                    metrics.resilience?.includes('High recovery') ? 'border-green-800' :
+                    metrics.resilience?.includes('Balanced') ? 'border-zinc-700' :
+                    metrics.resilience?.includes('Elevated') ? 'border-yellow-700' :
+                    metrics.resilience?.includes('High stress') ? 'border-red-800' :
+                    'border-zinc-800'
+                  }`}>
+                    <div className="flex justify-between items-baseline">
+                      <div>
+                        <div className="text-xs text-gray-500">Resilience</div>
+                        <div className="text-sm font-medium text-white">{metrics.resilience || 'Calculating...'}</div>
+                      </div>
+                      <div className="text-right text-xs text-gray-500">
+                        {metrics.stress_min != null && <span>{metrics.stress_min}m stressed</span>}
+                        {metrics.stress_min != null && metrics.restored_min != null && <span> · </span>}
+                        {metrics.restored_min != null && <span>{metrics.restored_min}m restored</span>}
+                      </div>
+                    </div>
                   </div>
                 )}
 

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -35,6 +35,7 @@ interface Metrics {
   weight_stale?: boolean;
   back_pain?: number | null;
   yesterday_activities?: {
+    id?: number;
     name?: string;
     type?: string;
     distance?: number;
@@ -67,9 +68,14 @@ function ActivityRow({ activity }: { activity: Metrics['yesterday_activities'] e
   const time = activity.moving_time ? `${Math.round(activity.moving_time / 60)}min` : '';
   const hr = activity.average_heartrate ? `HR ${Math.round(activity.average_heartrate)}` : '';
   const parts = [dist, elev, time, hr].filter(Boolean).join(' · ');
+  const name = activity.name || 'Activity';
   return (
     <div className="text-sm text-gray-300">
-      <span className="text-white">{activity.name || 'Activity'}</span>
+      {activity.id ? (
+        <a href={`https://www.strava.com/activities/${activity.id}`} target="_blank" rel="noopener noreferrer" className="text-white hover:text-orange-400 underline decoration-zinc-600 hover:decoration-orange-400 transition-colors">{name}</a>
+      ) : (
+        <span className="text-white">{name}</span>
+      )}
       <span className="text-gray-500 ml-1">({activity.type})</span>
       {parts && <span className="text-gray-400 ml-2">{parts}</span>}
     </div>
@@ -198,6 +204,7 @@ export default function CoachPage() {
 
         if (stravaActivities.length > 0) {
           m.yesterday_activities = stravaActivities.slice(0, 5).map((a: Record<string, unknown>) => ({
+            id: a.id as number,
             name: a.name, type: a.sport_type || a.type,
             distance: a.distance as number, moving_time: a.moving_time as number,
             total_elevation_gain: a.total_elevation_gain as number,
@@ -430,23 +437,42 @@ export default function CoachPage() {
         {showHistory && (
           <div className="mb-6 space-y-2">
             {history.length === 0 && <p className="text-gray-500 text-sm">No past sessions.</p>}
-            {history.map(s => (
-              <details key={s.date} className="bg-zinc-900 border border-zinc-800 rounded">
-                <summary className="px-4 py-2 cursor-pointer text-sm text-gray-300 hover:text-white flex justify-between">
-                  <span>{epochDayToDate(s.date)}</span>
-                  <span className="text-gray-500">{s.conversation_turns} turn{s.conversation_turns !== 1 ? 's' : ''}</span>
-                </summary>
-                <div className="px-4 pb-3">
-                  {s.advice_summary && (
-                    <p className="text-sm text-gray-300 mb-2">{s.advice_summary}</p>
-                  )}
-                  <details className="text-xs">
-                    <summary className="text-gray-500 cursor-pointer">Full conversation</summary>
-                    <div className="mt-2 text-gray-400 whitespace-pre-wrap">{s.advice_full}</div>
-                  </details>
-                </div>
-              </details>
-            ))}
+            {history.map(s => {
+              // Parse data snapshot from stored advice_full
+              const hasSnapshot = s.advice_full.startsWith('[Data for this session]');
+              const convoMarker = '[Conversation]';
+              const convoIdx = hasSnapshot ? s.advice_full.indexOf(convoMarker) : -1;
+              const dataSnapshot = hasSnapshot && convoIdx > 0
+                ? s.advice_full.slice('[Data for this session]\n'.length, convoIdx).trim()
+                : null;
+              const conversation = convoIdx > 0
+                ? s.advice_full.slice(convoIdx + convoMarker.length).trim()
+                : s.advice_full;
+
+              return (
+                <details key={s.date} className="bg-zinc-900 border border-zinc-800 rounded">
+                  <summary className="px-4 py-2 cursor-pointer text-sm text-gray-300 hover:text-white flex justify-between">
+                    <span>{epochDayToDate(s.date)}</span>
+                    <span className="text-gray-500">{s.conversation_turns} turn{s.conversation_turns !== 1 ? 's' : ''}</span>
+                  </summary>
+                  <div className="px-4 pb-3 space-y-2">
+                    {s.advice_summary && (
+                      <p className="text-sm text-gray-300">{s.advice_summary}</p>
+                    )}
+                    {dataSnapshot && (
+                      <details className="text-xs">
+                        <summary className="text-gray-500 cursor-pointer">Metrics from this day</summary>
+                        <div className="mt-1 text-gray-500 whitespace-pre-wrap bg-zinc-950 rounded p-2">{dataSnapshot}</div>
+                      </details>
+                    )}
+                    <details className="text-xs">
+                      <summary className="text-gray-500 cursor-pointer">Full conversation</summary>
+                      <div className="mt-1 text-gray-400 whitespace-pre-wrap">{conversation}</div>
+                    </details>
+                  </div>
+                </details>
+              );
+            })}
           </div>
         )}
 

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -247,6 +247,22 @@ export async function build_data_injection(
         lines.push(`Stress: ${stressed_min ?? '?'}min stressed, ${restored_min ?? '?'}min restored`);
         metrics.stress_min = stressed_min;
         metrics.restored_min = restored_min;
+
+        // Resilience indicator: stress-recovery balance
+        if (stressed_min !== null && restored_min !== null) {
+          const total = stressed_min + restored_min;
+          if (total > 0) {
+            const recovery_pct = Math.round((restored_min / total) * 100);
+            let resilience: string;
+            if (recovery_pct >= 65) resilience = 'High recovery, low stress';
+            else if (recovery_pct >= 50) resilience = 'Balanced';
+            else if (recovery_pct >= 35) resilience = 'Elevated stress';
+            else resilience = 'High stress, low recovery';
+            metrics.resilience = resilience;
+            metrics.resilience_pct = recovery_pct;
+            lines.push(`Resilience: ${resilience} (${recovery_pct}% recovery)`);
+          }
+        }
       }
     }
     // Compute recovery status from available signals

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -68,6 +68,55 @@ function fmt_trend(value: number | null, trends: Map<string, TrendRow>, metric: 
   return s;
 }
 
+function compute_recovery_status(
+  readiness: number | null,
+  hrv: number | null,
+  sleep: OuraSleepDetail | null,
+  stress: OuraStressDetail | null,
+  rhr: number | null,
+  trends: Map<string, TrendRow>,
+): string {
+  if (readiness === null && hrv === null) return 'No data';
+
+  // Gather signals
+  const hrv_trend = trends.get('hrv_rmssd');
+  const hrv_declining = hrv_trend?.value_7day_direction === 'declining';
+  const hrv_improving = hrv_trend?.value_7day_direction === 'improving';
+
+  const deep_ok = sleep?.deep_sleep_duration ? sleep.deep_sleep_duration >= 3600 : null; // >= 1hr deep
+  const sleep_ok = sleep?.total_sleep_duration ? sleep.total_sleep_duration >= 25200 : null; // >= 7hr total
+  const efficiency_ok = sleep?.efficiency ? sleep.efficiency >= 85 : null;
+
+  const stress_ratio = (stress?.stress_high && stress?.recovery_high)
+    ? stress.recovery_high / (stress.stress_high + stress.recovery_high)
+    : null;
+  const well_recovered = stress_ratio !== null ? stress_ratio >= 0.5 : null;
+
+  // Score: each positive signal adds 1, each negative subtracts 1
+  let score = 0;
+  if (readiness !== null) {
+    if (readiness >= 85) score += 2;
+    else if (readiness >= 70) score += 1;
+    else if (readiness < 60) score -= 2;
+    else score -= 1;
+  }
+  if (hrv_declining) score -= 1;
+  if (hrv_improving) score += 1;
+  if (deep_ok === true) score += 1;
+  if (deep_ok === false) score -= 1;
+  if (sleep_ok === true) score += 1;
+  if (sleep_ok === false) score -= 1;
+  if (efficiency_ok === false) score -= 1;
+  if (well_recovered === true) score += 1;
+  if (well_recovered === false) score -= 1;
+
+  if (score >= 4) return 'Ready to push';
+  if (score >= 2) return 'Ready — moderate effort';
+  if (score >= 0) return 'Easy day';
+  if (score >= -2) return 'Recovery — light movement only';
+  return 'Rest day';
+}
+
 /**
  * Build the data injection string for a coaching session.
  * date_str: YYYY-MM-DD format
@@ -168,11 +217,14 @@ export async function build_data_injection(
     if (sleep) {
       const total = sleep.total_sleep_duration ? seconds_to_hm(sleep.total_sleep_duration) : 'N/A';
       const deep = sleep.deep_sleep_duration ? seconds_to_hm(sleep.deep_sleep_duration) : 'N/A';
+      const rem = sleep.rem_sleep_duration ? seconds_to_hm(sleep.rem_sleep_duration) : 'N/A';
       const deep_min = sleep.deep_sleep_duration ? Math.round(sleep.deep_sleep_duration / 60) : null;
+      const rem_min = sleep.rem_sleep_duration ? Math.round(sleep.rem_sleep_duration / 60) : null;
       const efficiency = sleep.efficiency ? `${sleep.efficiency}%` : 'N/A';
-      lines.push(`Sleep: ${total} total, ${deep} deep, efficiency ${efficiency}`);
+      lines.push(`Sleep: ${total} total, ${deep} deep, ${rem} REM, efficiency ${efficiency}`);
       metrics.sleep_total = sleep.total_sleep_duration ? Math.round(sleep.total_sleep_duration / 60) : null;
       metrics.deep_sleep_min = deep_min;
+      metrics.rem_sleep_min = rem_min;
       metrics.sleep_efficiency = sleep.efficiency ?? null;
     } else if (oura.sleep_score) {
       lines.push(`Sleep score: ${oura.sleep_score}`);
@@ -197,6 +249,12 @@ export async function build_data_injection(
         metrics.restored_min = restored_min;
       }
     }
+    // Compute recovery status from available signals
+    const recovery_status = compute_recovery_status(
+      readiness_val, hrv_val, sleep, stress, rhr_val, trends
+    );
+    metrics.recovery_status = recovery_status;
+    lines.push(`Recovery status: ${recovery_status}`);
   } else {
     lines.push('No Oura data available');
   }

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -199,10 +199,24 @@ export async function save_coaching_session(session: {
  * Populate daily_metrics from wellness_cache (Oura) + coros_data (COROS) + optional manual inputs.
  * date_str: YYYY-MM-DD, epoch_day: Math.floor(Date.now() / 86400000)
  */
+export interface InjectMetrics {
+  readiness?: number | null;
+  hrv?: number | null;
+  resting_hr?: number | null;
+  spo2?: number | null;
+  sleep_total?: number | null;
+  deep_sleep_min?: number | null;
+  rem_sleep_min?: number | null;
+  sleep_efficiency?: number | null;
+  stress_min?: number | null;
+  restored_min?: number | null;
+}
+
 export async function populate_daily_metrics(
   date_str: string,
   epoch_day: number,
-  manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string }
+  manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string },
+  inject_metrics?: InjectMetrics,
 ): Promise<boolean> {
   await ensure_schema();
   const db = get_client();
@@ -213,7 +227,7 @@ export async function populate_daily_metrics(
     get_coros_data(date_str),
   ]);
 
-  // Extract Oura fields
+  // Extract Oura fields — prefer cache, fall back to inject_metrics from live session
   let sleep_duration_min: number | null = null;
   let sleep_efficiency_pct: number | null = null;
   let deep_sleep_min: number | null = null;
@@ -241,6 +255,15 @@ export async function populate_daily_metrics(
 
     const cv = oura.daily_cardiovascular_age as { vascular_age?: number } | null;
     if (cv?.vascular_age) cardiovascular_age = cv.vascular_age;
+  } else if (inject_metrics) {
+    // No cache for today — use metrics computed during inject from live Oura data
+    hrv_rmssd = inject_metrics.hrv ?? null;
+    resting_hr = inject_metrics.resting_hr ?? null;
+    readiness_score = inject_metrics.readiness ?? null;
+    sleep_duration_min = inject_metrics.sleep_total ?? null;
+    sleep_efficiency_pct = inject_metrics.sleep_efficiency ?? null;
+    deep_sleep_min = inject_metrics.deep_sleep_min ?? null;
+    rem_sleep_min = inject_metrics.rem_sleep_min ?? null;
   }
 
   // Extract COROS fields


### PR DESCRIPTION
## Summary
Addresses #197 items 1–5 and 6b/6c.

- **Recovery status** replaces readiness score — color-coded banner (Ready to push / moderate / easy / recovery / rest) calculated from readiness, HRV trend, sleep quality, stress-recovery ratio
- **Sleep durations** replace sleep score — total, deep, REM shown as actual times
- **SpO2 demoted** from prominent card to small "Blood oxygen: XX%" line under sleep
- **Resilience indicator** from Oura stress/recovery data — text label with color-coded border and raw minutes
- **Strava activity links** — activity names link to strava.com activity pages
- **History: metrics context** — past sessions show expandable "Metrics from this day" section
- **Fix: daily_metrics pipeline** — Oura fields were always null because today's data isn't cached; now passes live inject metrics through finalize as fallback

Not included: biological age (API returns null), history pagination (15 sessions doesn't need it yet), session summary backfill (tracked separately).

## Test plan
- [ ] Open /coach — verify recovery status banner appears with correct color
- [ ] Verify sleep section shows total/deep/REM as durations (e.g. "7h 23m"), not scores
- [ ] Verify SpO2 appears as small text under sleep, not its own card
- [ ] Verify resilience card shows stress-recovery balance text with minutes detail
- [ ] Click an activity name — should open Strava activity page in new tab
- [ ] Click History — expand a recent session (Apr 29+), verify summary shows, "Metrics from this day" expandable appears
- [ ] Start a session, chat, save — verify session saves successfully
- [ ] After save, check History again — new session should have metrics context

**Preview:** will be available at Vercel preview URL once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)