### PR TITLE
Add voice-to-text mic button to text-cleaner (#195)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(self), geolocation=()' },
         ],
       },
     ];

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -5,8 +5,9 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 
 interface TextNote {
   id: string;
@@ -30,6 +31,7 @@ export default function TextCleanerPage() {
   const [notes, set_notes] = useState<TextNote[]>([]);
   const [confirm_delete_id, set_confirm_delete_id] = useState<string | null>(null);
   const [confirm_delete_context, set_confirm_delete_context] = useState<'copy' | 'story' | null>(null);
+  const input_ref = useRef<HTMLTextAreaElement>(null);
 
   const fetch_notes = useCallback(async () => {
     try {
@@ -356,9 +358,13 @@ export default function TextCleanerPage() {
           <div className="bg-white/5 rounded-xl border border-white/10 overflow-hidden">
             <div className="bg-white/5 px-4 py-2 border-b border-white/10 flex justify-between items-center">
               <h3 className="font-medium text-gray-300">Your Text</h3>
-              <span className="text-xs text-gray-400">{input.length.toLocaleString()} chars</span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400">{input.length.toLocaleString()} chars</span>
+                <MicButton textarea_ref={input_ref} value={input} on_change={set_input} />
+              </div>
             </div>
             <textarea
+              ref={input_ref}
               value={input}
               onChange={e => set_input(e.target.value)}
               placeholder="Paste or type what you're trying to say. Don't worry about grammar, spelling, or structure — just get it down."

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -74,11 +74,29 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
 
   useEffect(() => {
     const ctor = get_recognition_ctor();
+    const has_md = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
+    const has_perms = typeof navigator !== 'undefined' && !!(navigator as Navigator & { permissions?: unknown }).permissions;
+    let in_iframe: boolean | 'unknown' = 'unknown';
+    if (typeof window !== 'undefined') {
+      try { in_iframe = window.top !== window.self; } catch { in_iframe = true; }
+    }
+    let policy_allows: boolean | 'unknown' = 'unknown';
+    try {
+      const fp = (typeof document !== 'undefined'
+        ? (document as Document & { featurePolicy?: { allowsFeature?: (n: string) => boolean } }).featurePolicy
+        : undefined);
+      if (fp?.allowsFeature) policy_allows = fp.allowsFeature('microphone');
+    } catch { /* ignore */ }
     mic_log('feature detection:', {
-      has_ctor: !!ctor,
+      has_speech_recognition_ctor: !!ctor,
       has_SpeechRecognition: typeof window !== 'undefined' && 'SpeechRecognition' in window,
       has_webkitSpeechRecognition: typeof window !== 'undefined' && 'webkitSpeechRecognition' in window,
+      has_getUserMedia: has_md,
+      has_permissions_api: has_perms,
       is_secure_context: typeof window !== 'undefined' && window.isSecureContext,
+      in_iframe,
+      feature_policy_allows_microphone: policy_allows,
+      origin: typeof window !== 'undefined' ? window.location.origin : 'unknown',
       user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
     });
     if (!ctor) {
@@ -225,27 +243,17 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
 
     if (phase !== 'idle') return;
 
-    // Step 1: probe Permissions API. If browser-level state is "denied",
-    // calling getUserMedia or recognition.start() will instantly fail without
-    // showing a prompt — give actionable instructions instead.
     set_phase('starting');
     set_status_text('');
     set_is_error(false);
 
-    const perm_state = await query_mic_permission();
-    mic_log('permission state', perm_state);
+    // Diagnostic only: log the pre-flight permission state, but DO NOT gate
+    // on it. Some environments (Permissions-Policy, stale browser state)
+    // report 'denied' even when an actual call would succeed or surface the
+    // prompt. We let getUserMedia be the source of truth.
+    const pre_state = await query_mic_permission();
+    mic_log('pre-flight permission state', pre_state);
 
-    if (perm_state === 'denied') {
-      set_phase('idle');
-      set_status_text('Mic blocked — reset in browser site settings');
-      set_is_error(true);
-      return;
-    }
-
-    // Step 2: explicitly request the mic via getUserMedia. This is what
-    // actually surfaces the browser's permission prompt UI on most platforms.
-    // SpeechRecognition.start() alone is unreliable for prompting outside
-    // localhost in current Chrome.
     if (!navigator.mediaDevices?.getUserMedia) {
       mic_log('getUserMedia unavailable');
       set_phase('idle');
@@ -254,24 +262,41 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       return;
     }
 
+    // Always call getUserMedia. On a fresh profile this triggers the actual
+    // browser permission prompt. On a previously-denied origin it rejects
+    // immediately with NotAllowedError and we use permissions.query AFTER
+    // the rejection to distinguish "user just dismissed/denied" from
+    // "browser-level block".
     let stream: MediaStream;
     try {
-      mic_log('calling getUserMedia');
+      mic_log('calling getUserMedia({ audio: true })');
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       mic_log('getUserMedia granted');
     } catch (err) {
       const name = (err as DOMException).name;
-      mic_log('getUserMedia rejected', { name, message: (err as Error).message });
+      const message = (err as Error).message;
+      mic_log('getUserMedia rejected', { name, message });
       set_phase('idle');
       set_is_error(true);
+
       if (name === 'NotAllowedError' || name === 'SecurityError') {
-        set_status_text('Permission denied — allow mic in address bar');
+        // Disambiguate via permissions.query. If state is now 'denied', the
+        // origin is blocked at the browser level (sticky); the user must
+        // reset it manually. If still 'prompt', they dismissed without a
+        // permanent decision — clicking again may show the prompt again.
+        const post_state = await query_mic_permission();
+        mic_log('post-rejection permission state', post_state);
+        if (post_state === 'denied') {
+          set_status_text('Mic is blocked at the browser level. Click the address-bar lock icon → reset Microphone → reload.');
+        } else {
+          set_status_text('Permission not granted. Click the mic again to retry.');
+        }
       } else if (name === 'NotFoundError' || name === 'OverconstrainedError') {
-        set_status_text('No microphone detected');
+        set_status_text('No microphone detected.');
       } else if (name === 'NotReadableError') {
-        set_status_text('Mic in use by another app');
+        set_status_text('Microphone is in use by another app.');
       } else {
-        set_status_text(`Mic error: ${name}`);
+        set_status_text(`Microphone error: ${name || message || 'unknown'}`);
       }
       return;
     }

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -2,12 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-function mic_log(...args: unknown[]) {
-  // Lightweight breadcrumbs for debugging voice input in Preview / production.
-  // Prefix makes them easy to filter in devtools.
-  console.log('[mic]', ...args);
-}
-
 type SpeechRecognitionAlternative = { transcript: string };
 type SpeechRecognitionResult = { isFinal: boolean; 0: SpeechRecognitionAlternative; length: number };
 type SpeechRecognitionResultList = { length: number; [i: number]: SpeechRecognitionResult };
@@ -74,31 +68,6 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
 
   useEffect(() => {
     const ctor = get_recognition_ctor();
-    const has_md = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
-    const has_perms = typeof navigator !== 'undefined' && !!(navigator as Navigator & { permissions?: unknown }).permissions;
-    let in_iframe: boolean | 'unknown' = 'unknown';
-    if (typeof window !== 'undefined') {
-      try { in_iframe = window.top !== window.self; } catch { in_iframe = true; }
-    }
-    let policy_allows: boolean | 'unknown' = 'unknown';
-    try {
-      const fp = (typeof document !== 'undefined'
-        ? (document as Document & { featurePolicy?: { allowsFeature?: (n: string) => boolean } }).featurePolicy
-        : undefined);
-      if (fp?.allowsFeature) policy_allows = fp.allowsFeature('microphone');
-    } catch { /* ignore */ }
-    mic_log('feature detection:', {
-      has_speech_recognition_ctor: !!ctor,
-      has_SpeechRecognition: typeof window !== 'undefined' && 'SpeechRecognition' in window,
-      has_webkitSpeechRecognition: typeof window !== 'undefined' && 'webkitSpeechRecognition' in window,
-      has_getUserMedia: has_md,
-      has_permissions_api: has_perms,
-      is_secure_context: typeof window !== 'undefined' && window.isSecureContext,
-      in_iframe,
-      feature_policy_allows_microphone: policy_allows,
-      origin: typeof window !== 'undefined' ? window.location.origin : 'unknown',
-      user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
-    });
     if (!ctor) {
       set_supported(false);
       return;
@@ -111,7 +80,6 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     recognition.lang = lang;
 
     recognition.onstart = () => {
-      mic_log('onstart fired');
       clear_watchdog();
       set_phase('recording');
       set_is_error(false);
@@ -119,7 +87,6 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     };
 
     recognition.onresult = (event) => {
-      mic_log('onresult', { resultIndex: event.resultIndex, results_length: event.results.length });
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
         if (!result.isFinal) continue;
@@ -129,7 +96,6 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     };
 
     recognition.onerror = (event) => {
-      mic_log('onerror', { error: event.error });
       clear_watchdog();
       const friendly = error_messages[event.error] ?? `Voice input error: ${event.error}`;
       set_status_text(friendly);
@@ -139,13 +105,11 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     };
 
     recognition.onend = () => {
-      mic_log('onend', { wants_recording: wants_recording_ref.current, cancelled: cancelled_ref.current });
       if (cancelled_ref.current) return;
       if (wants_recording_ref.current) {
         try {
           recognition.start();
         } catch (err) {
-          mic_log('restart threw', err);
           if ((err as { name?: string }).name !== 'InvalidStateError') {
             wants_recording_ref.current = false;
             set_phase('idle');
@@ -223,7 +187,6 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   }
 
   async function handle_click() {
-    mic_log('click', { supported, phase, has_recognition: !!recognition_ref.current });
     if (!supported) return;
     if (phase === 'starting' || phase === 'stopping') return;
 
@@ -247,45 +210,30 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     set_status_text('');
     set_is_error(false);
 
-    // Diagnostic only: log the pre-flight permission state, but DO NOT gate
-    // on it. Some environments (Permissions-Policy, stale browser state)
-    // report 'denied' even when an actual call would succeed or surface the
-    // prompt. We let getUserMedia be the source of truth.
-    const pre_state = await query_mic_permission();
-    mic_log('pre-flight permission state', pre_state);
-
     if (!navigator.mediaDevices?.getUserMedia) {
-      mic_log('getUserMedia unavailable');
       set_phase('idle');
       set_status_text('Voice input unavailable in this browser.');
       set_is_error(true);
       return;
     }
 
-    // Always call getUserMedia. On a fresh profile this triggers the actual
-    // browser permission prompt. On a previously-denied origin it rejects
-    // immediately with NotAllowedError and we use permissions.query AFTER
-    // the rejection to distinguish "user just dismissed/denied" from
-    // "browser-level block".
+    // Call getUserMedia first — this is what surfaces the browser's mic
+    // permission prompt on a fresh profile. SpeechRecognition.start() alone
+    // does not reliably prompt on non-localhost origins.
     let stream: MediaStream;
     try {
-      mic_log('calling getUserMedia({ audio: true })');
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      mic_log('getUserMedia granted');
     } catch (err) {
       const name = (err as DOMException).name;
       const message = (err as Error).message;
-      mic_log('getUserMedia rejected', { name, message });
       set_phase('idle');
       set_is_error(true);
 
       if (name === 'NotAllowedError' || name === 'SecurityError') {
-        // Disambiguate via permissions.query. If state is now 'denied', the
-        // origin is blocked at the browser level (sticky); the user must
-        // reset it manually. If still 'prompt', they dismissed without a
-        // permanent decision — clicking again may show the prompt again.
+        // Disambiguate via permissions.query: 'denied' means a sticky
+        // browser-level block; anything else means the user dismissed and
+        // can retry.
         const post_state = await query_mic_permission();
-        mic_log('post-rejection permission state', post_state);
         if (post_state === 'denied') {
           set_status_text('Mic is blocked at the browser level. Click the address-bar lock icon → reset Microphone → reload.');
         } else {
@@ -301,29 +249,21 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       return;
     }
 
-    // We don't need the stream — SpeechRecognition manages its own audio.
-    // Releasing tracks promptly avoids leaving the browser's mic indicator on
-    // longer than necessary.
+    // SpeechRecognition manages its own audio capture; release the stream
+    // so the browser's mic indicator only stays on while recognition runs.
     stream.getTracks().forEach((t) => { try { t.stop(); } catch { /* ignore */ } });
 
-    // Step 3: now start recognition. Permission is granted at this point;
-    // start() should fire onstart shortly. The watchdog catches the rare case
-    // where neither onstart nor onerror fires.
     wants_recording_ref.current = true;
     try {
-      mic_log('calling recognition.start()');
       recognition.start();
-      mic_log('recognition.start() returned');
       clear_watchdog();
       startup_watchdog_ref.current = window.setTimeout(() => {
-        mic_log('startup watchdog fired — no onstart/onerror within 3s');
         wants_recording_ref.current = false;
         set_phase('idle');
         set_status_text('Mic did not start. Try again, or reload the page.');
         set_is_error(true);
       }, 3000);
     } catch (err) {
-      mic_log('start() threw', err);
       wants_recording_ref.current = false;
       set_phase('idle');
       set_status_text(`Voice input error: ${(err as Error).message ?? 'unknown'}`);
@@ -340,8 +280,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       const state = result.state;
       if (state === 'granted' || state === 'denied' || state === 'prompt') return state;
       return 'unknown';
-    } catch (err) {
-      mic_log('permissions.query threw', err);
+    } catch {
       return 'unknown';
     }
   }

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -204,7 +204,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     });
   }
 
-  function handle_click() {
+  async function handle_click() {
     mic_log('click', { supported, phase, has_recognition: !!recognition_ref.current });
     if (!supported) return;
     if (phase === 'starting' || phase === 'stopping') return;
@@ -216,40 +216,108 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       return;
     }
 
-    if (phase === 'idle') {
-      wants_recording_ref.current = true;
-      set_phase('starting');
-      set_status_text('');
-      set_is_error(false);
-      try {
-        mic_log('calling recognition.start()');
-        recognition.start();
-        mic_log('recognition.start() returned');
-        // Watchdog: if neither onstart nor onerror fires within 2s, surface a
-        // visible error. Some browsers (or Permissions-Policy blocks) silently
-        // do nothing here.
-        clear_watchdog();
-        startup_watchdog_ref.current = window.setTimeout(() => {
-          mic_log('startup watchdog fired — no onstart/onerror within 2s');
-          wants_recording_ref.current = false;
-          set_phase('idle');
-          set_status_text('Mic did not start. Check browser permissions.');
-          set_is_error(true);
-        }, 2000);
-      } catch (err) {
-        mic_log('start() threw', err);
-        wants_recording_ref.current = false;
-        set_phase('idle');
-        set_status_text(`Voice input error: ${(err as Error).message ?? 'unknown'}`);
-        set_is_error(true);
-      }
-      return;
-    }
-
     if (phase === 'recording') {
       wants_recording_ref.current = false;
       set_phase('stopping');
       try { recognition.stop(); } catch { /* ignore */ }
+      return;
+    }
+
+    if (phase !== 'idle') return;
+
+    // Step 1: probe Permissions API. If browser-level state is "denied",
+    // calling getUserMedia or recognition.start() will instantly fail without
+    // showing a prompt — give actionable instructions instead.
+    set_phase('starting');
+    set_status_text('');
+    set_is_error(false);
+
+    const perm_state = await query_mic_permission();
+    mic_log('permission state', perm_state);
+
+    if (perm_state === 'denied') {
+      set_phase('idle');
+      set_status_text('Mic blocked — reset in browser site settings');
+      set_is_error(true);
+      return;
+    }
+
+    // Step 2: explicitly request the mic via getUserMedia. This is what
+    // actually surfaces the browser's permission prompt UI on most platforms.
+    // SpeechRecognition.start() alone is unreliable for prompting outside
+    // localhost in current Chrome.
+    if (!navigator.mediaDevices?.getUserMedia) {
+      mic_log('getUserMedia unavailable');
+      set_phase('idle');
+      set_status_text('Voice input unavailable in this browser.');
+      set_is_error(true);
+      return;
+    }
+
+    let stream: MediaStream;
+    try {
+      mic_log('calling getUserMedia');
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mic_log('getUserMedia granted');
+    } catch (err) {
+      const name = (err as DOMException).name;
+      mic_log('getUserMedia rejected', { name, message: (err as Error).message });
+      set_phase('idle');
+      set_is_error(true);
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        set_status_text('Permission denied — allow mic in address bar');
+      } else if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+        set_status_text('No microphone detected');
+      } else if (name === 'NotReadableError') {
+        set_status_text('Mic in use by another app');
+      } else {
+        set_status_text(`Mic error: ${name}`);
+      }
+      return;
+    }
+
+    // We don't need the stream — SpeechRecognition manages its own audio.
+    // Releasing tracks promptly avoids leaving the browser's mic indicator on
+    // longer than necessary.
+    stream.getTracks().forEach((t) => { try { t.stop(); } catch { /* ignore */ } });
+
+    // Step 3: now start recognition. Permission is granted at this point;
+    // start() should fire onstart shortly. The watchdog catches the rare case
+    // where neither onstart nor onerror fires.
+    wants_recording_ref.current = true;
+    try {
+      mic_log('calling recognition.start()');
+      recognition.start();
+      mic_log('recognition.start() returned');
+      clear_watchdog();
+      startup_watchdog_ref.current = window.setTimeout(() => {
+        mic_log('startup watchdog fired — no onstart/onerror within 3s');
+        wants_recording_ref.current = false;
+        set_phase('idle');
+        set_status_text('Mic did not start. Try again, or reload the page.');
+        set_is_error(true);
+      }, 3000);
+    } catch (err) {
+      mic_log('start() threw', err);
+      wants_recording_ref.current = false;
+      set_phase('idle');
+      set_status_text(`Voice input error: ${(err as Error).message ?? 'unknown'}`);
+      set_is_error(true);
+    }
+  }
+
+  async function query_mic_permission(): Promise<'granted' | 'denied' | 'prompt' | 'unknown'> {
+    type PermsLike = { query: (d: { name: string }) => Promise<{ state: string }> };
+    const perms = (navigator as Navigator & { permissions?: PermsLike }).permissions;
+    if (!perms?.query) return 'unknown';
+    try {
+      const result = await perms.query({ name: 'microphone' });
+      const state = result.state;
+      if (state === 'granted' || state === 'denied' || state === 'prompt') return state;
+      return 'unknown';
+    } catch (err) {
+      mic_log('permissions.query threw', err);
+      return 'unknown';
     }
   }
 
@@ -270,7 +338,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   // so silent failures (permission denied, Permissions-Policy block, etc.) are
   // never invisible. "Listening" stays visual-only via the red-pulse mic.
   const visible_status = is_error ? status_text : '';
-  const visible_status_class = 'text-xs text-red-400 max-w-[14rem] truncate';
+  const visible_status_class = 'text-xs text-red-400 leading-tight';
 
   return (
     <span className="inline-flex items-center gap-2">

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type SpeechRecognitionAlternative = { transcript: string };
+type SpeechRecognitionResult = { isFinal: boolean; 0: SpeechRecognitionAlternative; length: number };
+type SpeechRecognitionResultList = { length: number; [i: number]: SpeechRecognitionResult };
+type SpeechRecognitionEvent = { resultIndex: number; results: SpeechRecognitionResultList };
+type SpeechRecognitionErrorEvent = { error: string };
+
+interface SpeechRecognitionInstance {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((e: SpeechRecognitionEvent) => void) | null;
+  onerror: ((e: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  onstart: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+}
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
+function get_recognition_ctor(): SpeechRecognitionCtor | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+const error_messages: Record<string, string> = {
+  'not-allowed': 'Microphone permission denied',
+  'service-not-allowed': 'Microphone permission denied',
+  'audio-capture': 'No microphone detected',
+  'no-speech': 'No speech heard',
+  'network': 'Network error',
+};
+
+type Phase = 'idle' | 'starting' | 'recording' | 'stopping';
+
+interface Props {
+  textarea_ref: React.RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  on_change: (next: string) => void;
+  lang?: string;
+  className?: string;
+}
+
+export default function MicButton({ textarea_ref, value, on_change, lang = 'en-US', className }: Props) {
+  const [supported, set_supported] = useState(false);
+  const [phase, set_phase] = useState<Phase>('idle');
+  const [status_text, set_status_text] = useState('');
+
+  const recognition_ref = useRef<SpeechRecognitionInstance | null>(null);
+  const value_ref = useRef(value);
+  const on_change_ref = useRef(on_change);
+  const wants_recording_ref = useRef(false);
+  const cancelled_ref = useRef(false);
+
+  useEffect(() => { value_ref.current = value; }, [value]);
+  useEffect(() => { on_change_ref.current = on_change; }, [on_change]);
+
+  useEffect(() => {
+    const ctor = get_recognition_ctor();
+    if (!ctor) {
+      set_supported(false);
+      return;
+    }
+    set_supported(true);
+
+    const recognition = new ctor();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.lang = lang;
+
+    recognition.onstart = () => {
+      set_phase('recording');
+      set_status_text('Listening');
+    };
+
+    recognition.onresult = (event) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (!result.isFinal) continue;
+        const transcript = result[0].transcript;
+        insert_transcript(transcript);
+      }
+    };
+
+    recognition.onerror = (event) => {
+      const friendly = error_messages[event.error] ?? `Voice input error: ${event.error}`;
+      set_status_text(friendly);
+      wants_recording_ref.current = false;
+      set_phase('idle');
+    };
+
+    recognition.onend = () => {
+      if (cancelled_ref.current) return;
+      if (wants_recording_ref.current) {
+        try {
+          recognition.start();
+        } catch (err) {
+          if ((err as { name?: string }).name !== 'InvalidStateError') {
+            wants_recording_ref.current = false;
+            set_phase('idle');
+            set_status_text('Voice input error');
+          }
+        }
+      } else {
+        set_phase('idle');
+        set_status_text((prev) => (prev === 'Listening' ? 'Stopped' : prev));
+      }
+    };
+
+    recognition_ref.current = recognition;
+
+    return () => {
+      cancelled_ref.current = true;
+      wants_recording_ref.current = false;
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      recognition.onstart = null;
+      try { recognition.abort(); } catch { /* ignore */ }
+      recognition_ref.current = null;
+    };
+  }, [lang]);
+
+  function insert_transcript(transcript: string) {
+    const current = value_ref.current;
+    const ta = textarea_ref.current;
+
+    let start = current.length;
+    let end = current.length;
+    if (ta) {
+      const s = ta.selectionStart;
+      const e = ta.selectionEnd;
+      if (typeof s === 'number' && typeof e === 'number' && s >= 0 && e >= s && e <= current.length) {
+        start = s;
+        end = e;
+      }
+    }
+
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+
+    let inserted = transcript;
+    const prev_char = before.slice(-1);
+    if (prev_char && !/\s/.test(prev_char) && !/^\s/.test(inserted)) {
+      inserted = ' ' + inserted;
+    }
+    const next_char = after.slice(0, 1);
+    if (next_char && !/\s/.test(next_char) && !/\s$/.test(inserted)) {
+      inserted = inserted + ' ';
+    }
+
+    const next_value = before + inserted + after;
+    value_ref.current = next_value;
+    on_change_ref.current(next_value);
+
+    const caret = (before + inserted).length;
+    requestAnimationFrame(() => {
+      const ta_now = textarea_ref.current;
+      if (ta_now) {
+        try { ta_now.setSelectionRange(caret, caret); } catch { /* ignore */ }
+      }
+    });
+  }
+
+  function handle_click() {
+    if (!supported) return;
+    if (phase === 'starting' || phase === 'stopping') return;
+
+    const recognition = recognition_ref.current;
+    if (!recognition) return;
+
+    if (phase === 'idle') {
+      wants_recording_ref.current = true;
+      set_phase('starting');
+      set_status_text('');
+      try {
+        recognition.start();
+      } catch {
+        wants_recording_ref.current = false;
+        set_phase('idle');
+        set_status_text('Voice input error');
+      }
+      return;
+    }
+
+    if (phase === 'recording') {
+      wants_recording_ref.current = false;
+      set_phase('stopping');
+      try { recognition.stop(); } catch { /* ignore */ }
+    }
+  }
+
+  const recording = phase === 'recording' || phase === 'starting';
+  const base_class = 'p-2 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/50 disabled:opacity-40 disabled:cursor-not-allowed';
+  const color_class = recording
+    ? 'text-red-400 animate-pulse'
+    : 'text-gray-400 hover:text-cyan-400';
+  const merged_class = [base_class, color_class, className].filter(Boolean).join(' ');
+
+  const title = !supported
+    ? 'Voice input needs Chrome or Edge'
+    : recording
+      ? 'Stop voice input'
+      : 'Start voice input';
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handle_click}
+        disabled={!supported}
+        title={title}
+        aria-label={recording ? 'Stop voice input' : 'Start voice input'}
+        aria-pressed={recording}
+        className={merged_class}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-5 h-5"
+          aria-hidden="true"
+        >
+          <rect x="9" y="3" width="6" height="12" rx="3" />
+          <path d="M5 11a7 7 0 0 0 14 0" />
+          <line x1="12" y1="18" x2="12" y2="22" />
+          <line x1="8" y1="22" x2="16" y2="22" />
+        </svg>
+      </button>
+      <span role="status" aria-live="polite" className="sr-only">
+        {status_text}
+      </span>
+    </>
+  );
+}

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type SpeechRecognitionAlternative = { transcript: string };
 type SpeechRecognitionResult = { isFinal: boolean; 0: SpeechRecognitionAlternative; length: number };
@@ -51,7 +51,7 @@ interface Props {
 }
 
 export default function MicButton({ textarea_ref, value, on_change, lang = 'en-US', className }: Props) {
-  const [supported, set_supported] = useState(false);
+  const [supported] = useState(() => !!get_recognition_ctor());
   const [phase, set_phase] = useState<Phase>('idle');
   const [status_text, set_status_text] = useState('');
   const [is_error, set_is_error] = useState(false);
@@ -66,13 +66,57 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   useEffect(() => { value_ref.current = value; }, [value]);
   useEffect(() => { on_change_ref.current = on_change; }, [on_change]);
 
+  const clear_watchdog = useCallback(() => {
+    if (startup_watchdog_ref.current !== null) {
+      window.clearTimeout(startup_watchdog_ref.current);
+      startup_watchdog_ref.current = null;
+    }
+  }, []);
+
+  const insert_transcript = useCallback((transcript: string) => {
+    const current = value_ref.current;
+    const ta = textarea_ref.current;
+
+    let start = current.length;
+    let end = current.length;
+    if (ta) {
+      const s = ta.selectionStart;
+      const e = ta.selectionEnd;
+      if (typeof s === 'number' && typeof e === 'number' && s >= 0 && e >= s && e <= current.length) {
+        start = s;
+        end = e;
+      }
+    }
+
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+
+    let inserted = transcript;
+    const prev_char = before.slice(-1);
+    if (prev_char && !/\s/.test(prev_char) && !/^\s/.test(inserted)) {
+      inserted = ' ' + inserted;
+    }
+    const next_char = after.slice(0, 1);
+    if (next_char && !/\s/.test(next_char) && !/\s$/.test(inserted)) {
+      inserted = inserted + ' ';
+    }
+
+    const next_value = before + inserted + after;
+    value_ref.current = next_value;
+    on_change_ref.current(next_value);
+
+    const caret = (before + inserted).length;
+    requestAnimationFrame(() => {
+      const ta_now = textarea_ref.current;
+      if (ta_now) {
+        try { ta_now.setSelectionRange(caret, caret); } catch { /* ignore */ }
+      }
+    });
+  }, [textarea_ref]);
+
   useEffect(() => {
     const ctor = get_recognition_ctor();
-    if (!ctor) {
-      set_supported(false);
-      return;
-    }
-    set_supported(true);
+    if (!ctor) return;
 
     const recognition = new ctor();
     recognition.continuous = false;
@@ -136,55 +180,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       try { recognition.abort(); } catch { /* ignore */ }
       recognition_ref.current = null;
     };
-  }, [lang]);
-
-  function clear_watchdog() {
-    if (startup_watchdog_ref.current !== null) {
-      window.clearTimeout(startup_watchdog_ref.current);
-      startup_watchdog_ref.current = null;
-    }
-  }
-
-  function insert_transcript(transcript: string) {
-    const current = value_ref.current;
-    const ta = textarea_ref.current;
-
-    let start = current.length;
-    let end = current.length;
-    if (ta) {
-      const s = ta.selectionStart;
-      const e = ta.selectionEnd;
-      if (typeof s === 'number' && typeof e === 'number' && s >= 0 && e >= s && e <= current.length) {
-        start = s;
-        end = e;
-      }
-    }
-
-    const before = current.slice(0, start);
-    const after = current.slice(end);
-
-    let inserted = transcript;
-    const prev_char = before.slice(-1);
-    if (prev_char && !/\s/.test(prev_char) && !/^\s/.test(inserted)) {
-      inserted = ' ' + inserted;
-    }
-    const next_char = after.slice(0, 1);
-    if (next_char && !/\s/.test(next_char) && !/\s$/.test(inserted)) {
-      inserted = inserted + ' ';
-    }
-
-    const next_value = before + inserted + after;
-    value_ref.current = next_value;
-    on_change_ref.current(next_value);
-
-    const caret = (before + inserted).length;
-    requestAnimationFrame(() => {
-      const ta_now = textarea_ref.current;
-      if (ta_now) {
-        try { ta_now.setSelectionRange(caret, caret); } catch { /* ignore */ }
-      }
-    });
-  }
+  }, [lang, clear_watchdog, insert_transcript]);
 
   async function handle_click() {
     if (!supported) return;

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -2,6 +2,12 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+function mic_log(...args: unknown[]) {
+  // Lightweight breadcrumbs for debugging voice input in Preview / production.
+  // Prefix makes them easy to filter in devtools.
+  console.log('[mic]', ...args);
+}
+
 type SpeechRecognitionAlternative = { transcript: string };
 type SpeechRecognitionResult = { isFinal: boolean; 0: SpeechRecognitionAlternative; length: number };
 type SpeechRecognitionResultList = { length: number; [i: number]: SpeechRecognitionResult };
@@ -54,18 +60,27 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   const [supported, set_supported] = useState(false);
   const [phase, set_phase] = useState<Phase>('idle');
   const [status_text, set_status_text] = useState('');
+  const [is_error, set_is_error] = useState(false);
 
   const recognition_ref = useRef<SpeechRecognitionInstance | null>(null);
   const value_ref = useRef(value);
   const on_change_ref = useRef(on_change);
   const wants_recording_ref = useRef(false);
   const cancelled_ref = useRef(false);
+  const startup_watchdog_ref = useRef<number | null>(null);
 
   useEffect(() => { value_ref.current = value; }, [value]);
   useEffect(() => { on_change_ref.current = on_change; }, [on_change]);
 
   useEffect(() => {
     const ctor = get_recognition_ctor();
+    mic_log('feature detection:', {
+      has_ctor: !!ctor,
+      has_SpeechRecognition: typeof window !== 'undefined' && 'SpeechRecognition' in window,
+      has_webkitSpeechRecognition: typeof window !== 'undefined' && 'webkitSpeechRecognition' in window,
+      is_secure_context: typeof window !== 'undefined' && window.isSecureContext,
+      user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
+    });
     if (!ctor) {
       set_supported(false);
       return;
@@ -78,11 +93,15 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     recognition.lang = lang;
 
     recognition.onstart = () => {
+      mic_log('onstart fired');
+      clear_watchdog();
       set_phase('recording');
+      set_is_error(false);
       set_status_text('Listening');
     };
 
     recognition.onresult = (event) => {
+      mic_log('onresult', { resultIndex: event.resultIndex, results_length: event.results.length });
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
         if (!result.isFinal) continue;
@@ -92,27 +111,33 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     };
 
     recognition.onerror = (event) => {
+      mic_log('onerror', { error: event.error });
+      clear_watchdog();
       const friendly = error_messages[event.error] ?? `Voice input error: ${event.error}`;
       set_status_text(friendly);
+      set_is_error(true);
       wants_recording_ref.current = false;
       set_phase('idle');
     };
 
     recognition.onend = () => {
+      mic_log('onend', { wants_recording: wants_recording_ref.current, cancelled: cancelled_ref.current });
       if (cancelled_ref.current) return;
       if (wants_recording_ref.current) {
         try {
           recognition.start();
         } catch (err) {
+          mic_log('restart threw', err);
           if ((err as { name?: string }).name !== 'InvalidStateError') {
             wants_recording_ref.current = false;
             set_phase('idle');
             set_status_text('Voice input error');
+            set_is_error(true);
           }
         }
       } else {
         set_phase('idle');
-        set_status_text((prev) => (prev === 'Listening' ? 'Stopped' : prev));
+        set_status_text((prev) => (prev === 'Listening' ? '' : prev));
       }
     };
 
@@ -121,6 +146,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
     return () => {
       cancelled_ref.current = true;
       wants_recording_ref.current = false;
+      clear_watchdog();
       recognition.onresult = null;
       recognition.onerror = null;
       recognition.onend = null;
@@ -129,6 +155,13 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       recognition_ref.current = null;
     };
   }, [lang]);
+
+  function clear_watchdog() {
+    if (startup_watchdog_ref.current !== null) {
+      window.clearTimeout(startup_watchdog_ref.current);
+      startup_watchdog_ref.current = null;
+    }
+  }
 
   function insert_transcript(transcript: string) {
     const current = value_ref.current;
@@ -172,22 +205,43 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   }
 
   function handle_click() {
+    mic_log('click', { supported, phase, has_recognition: !!recognition_ref.current });
     if (!supported) return;
     if (phase === 'starting' || phase === 'stopping') return;
 
     const recognition = recognition_ref.current;
-    if (!recognition) return;
+    if (!recognition) {
+      set_status_text('Voice input not initialized');
+      set_is_error(true);
+      return;
+    }
 
     if (phase === 'idle') {
       wants_recording_ref.current = true;
       set_phase('starting');
       set_status_text('');
+      set_is_error(false);
       try {
+        mic_log('calling recognition.start()');
         recognition.start();
-      } catch {
+        mic_log('recognition.start() returned');
+        // Watchdog: if neither onstart nor onerror fires within 2s, surface a
+        // visible error. Some browsers (or Permissions-Policy blocks) silently
+        // do nothing here.
+        clear_watchdog();
+        startup_watchdog_ref.current = window.setTimeout(() => {
+          mic_log('startup watchdog fired — no onstart/onerror within 2s');
+          wants_recording_ref.current = false;
+          set_phase('idle');
+          set_status_text('Mic did not start. Check browser permissions.');
+          set_is_error(true);
+        }, 2000);
+      } catch (err) {
+        mic_log('start() threw', err);
         wants_recording_ref.current = false;
         set_phase('idle');
-        set_status_text('Voice input error');
+        set_status_text(`Voice input error: ${(err as Error).message ?? 'unknown'}`);
+        set_is_error(true);
       }
       return;
     }
@@ -212,8 +266,14 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       ? 'Stop voice input'
       : 'Start voice input';
 
+  // Show status text visibly when it's an error or a non-listening message,
+  // so silent failures (permission denied, Permissions-Policy block, etc.) are
+  // never invisible. "Listening" stays visual-only via the red-pulse mic.
+  const visible_status = is_error ? status_text : '';
+  const visible_status_class = 'text-xs text-red-400 max-w-[14rem] truncate';
+
   return (
-    <>
+    <span className="inline-flex items-center gap-2">
       <button
         type="button"
         onClick={handle_click}
@@ -240,9 +300,14 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
           <line x1="8" y1="22" x2="16" y2="22" />
         </svg>
       </button>
+      {visible_status && (
+        <span className={visible_status_class} title={visible_status}>
+          {visible_status}
+        </span>
+      )}
       <span role="status" aria-live="polite" className="sr-only">
         {status_text}
       </span>
-    </>
+    </span>
   );
 }


### PR DESCRIPTION
Closes #195 (Phase 1).

## Summary

- New reusable `<MicButton>` component (`src/components/mic_button.tsx`) using the browser `SpeechRecognition` API. Inserts transcribed text at the textarea's caret position (or replaces the current selection), with spacing normalization.
- Wired into the "Your Text" input on `/creative/text-cleaner`. AI-generated `cleaned`/`story` outputs intentionally left out of v1 to avoid regeneration-clobber races — see follow-up below.
- Fixes site-wide `Permissions-Policy` header in `next.config.ts` from `microphone=()` to `microphone=(self)`. The empty allowlist was blocking the mic for all origins including self, which is why no permission prompt ever appeared during testing.

## Implementation notes

- **Permission flow**: click → `getUserMedia({ audio: true })` (this is what triggers the prompt) → on grant, release the stream and call `recognition.start()`. On `NotAllowedError`, `permissions.query` is consulted *afterwards* to disambiguate "user dismissed once" from "blocked at browser level" so the inline error message is actionable.
- **Reliability**: `continuous = false` with auto-restart in `onend` avoids Chrome's duplicate-finalized-chunk bug from `continuous = true`. `try/catch` around the restart swallows `InvalidStateError`. State machine (`idle`/`starting`/`recording`/`stopping`) prevents double-click races. 3-second startup watchdog catches the rare case where neither `onstart` nor `onerror` fires.
- **Cleanup**: refs (`cancelled_ref`, `wants_recording_ref`) gate the auto-restart so a teardown that races with an in-flight `onend` cannot resurrect recognition. All handlers nulled and `recognition.abort()` called on unmount.
- **A11y**: `aria-label` (toggles), `aria-pressed`, `role="status" aria-live="polite"` for screen readers, focus-visible ring, plus a visible inline error chip so silent failures aren't only sr-only.
- Selection-aware: dictating with text selected replaces the selection rather than inserting alongside it.

## Known limitations (documented; not addressed here)

- Safari has `webkitSpeechRecognition` but is unvalidated.
- Native textarea undo stack is bypassed by any React-controlled value change. Acceptable for POC.
- Mobile auto-stop behaviour is best-effort via the `onend` auto-restart.
- `lang` defaults to `en-US`; configurable via prop, no UI to switch.

## Test plan

- [x] On a Vercel Preview after the Permissions-Policy fix, Chrome shows the mic permission prompt on first click and dictation inserts at the caret (confirmed by repo owner).
- [ ] Verify response headers on Preview show `Permissions-Policy: camera=(), microphone=(self), geolocation=()`.
- [ ] Verify `npm run build` and `npm run lint` pass on CI / Vercel build (couldn't run locally — sandbox blocks `npm install`).
- [ ] Selection replacement: select "cruel" in "hello cruel world", dictate "wonderful" → result is "hello wonderful world".
- [ ] Long-session regression: ~60 seconds of continuous dictation with pauses, no duplicate transcripts.
- [ ] Permission-denied path renders a visible inline message (red) and does not get stuck in the `recording` state.
- [ ] Firefox renders the mic disabled with the tooltip; no console errors.

## Follow-up

Filing a separate issue for: rolling the same `<MicButton>` to the other ~9 candidate textareas (creative/edit, tools/markdown, tools/prompt-library, tools/instruction-stripper, tools/knowledge-diff, plus `cleaned`/`story` outputs), and Phase 2 swap to OpenAI Whisper for Safari/Firefox support and better accuracy.

https://claude.ai/code/session_0124ECFBg1i4s3EnzDGP7Cmw

---
_Generated by [Claude Code](https://claude.ai/code/session_0124ECFBg1i4s3EnzDGP7Cmw)_