### PR TITLE
Roll out MicButton to remaining textareas (Partial #209)

### DIFF
--- a/src/app/creative/edit/[id]/editor_client.tsx
+++ b/src/app/creative/edit/[id]/editor_client.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { startTransition, useDeferredValue, useState } from 'react';
+import { startTransition, useDeferredValue, useRef, useState } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 import { StoryAudit } from '@/lib/story_audit';
 import { build_story_body_html, extract_story_title } from '@/lib/story_markup';
 
@@ -33,6 +34,8 @@ export default function StoryEditor({
   const [rerunning_audit, set_rerunning_audit] = useState(false);
   const [status, set_status] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [audit_open, set_audit_open] = useState(true);
+  const blurb_ref = useRef<HTMLTextAreaElement>(null);
+  const content_ref = useRef<HTMLTextAreaElement>(null);
   const deferred_content = useDeferredValue(content);
 
   const preview_title = extract_story_title(deferred_content, story.date_display);
@@ -160,21 +163,29 @@ export default function StoryEditor({
                 </h2>
                 <span className="text-xs text-slate-500">Story ID: {story.id}</span>
               </div>
-              <label className="mb-3 block text-sm text-slate-300" htmlFor="story-blurb">
-                Blurb
-              </label>
+              <div className="mb-3 flex items-center justify-between">
+                <label className="block text-sm text-slate-300" htmlFor="story-blurb">
+                  Blurb
+                </label>
+                <MicButton textarea_ref={blurb_ref} value={blurb} on_change={set_blurb} />
+              </div>
               <textarea
                 id="story-blurb"
+                ref={blurb_ref}
                 value={blurb}
                 onChange={(event) => set_blurb(event.target.value)}
                 className="mb-5 min-h-24 w-full rounded-2xl border border-white/10 bg-[#0b1220] px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-300/50"
                 spellCheck={false}
               />
-              <label className="mb-3 block text-sm text-slate-300" htmlFor="story-html">
-                Story HTML
-              </label>
+              <div className="mb-3 flex items-center justify-between">
+                <label className="block text-sm text-slate-300" htmlFor="story-html">
+                  Story HTML
+                </label>
+                <MicButton textarea_ref={content_ref} value={content} on_change={set_content} />
+              </div>
               <textarea
                 id="story-html"
+                ref={content_ref}
                 value={content}
                 onChange={(event) => set_content(event.target.value)}
                 className="min-h-[28rem] w-full rounded-2xl border border-white/10 bg-[#0b1220] px-4 py-3 font-mono text-sm leading-6 text-slate-100 outline-none transition focus:border-cyan-300/50"

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -32,6 +32,8 @@ export default function TextCleanerPage() {
   const [confirm_delete_id, set_confirm_delete_id] = useState<string | null>(null);
   const [confirm_delete_context, set_confirm_delete_context] = useState<'copy' | 'story' | null>(null);
   const input_ref = useRef<HTMLTextAreaElement>(null);
+  const cleaned_ref = useRef<HTMLTextAreaElement>(null);
+  const story_ref = useRef<HTMLTextAreaElement>(null);
 
   const fetch_notes = useCallback(async () => {
     try {
@@ -360,7 +362,7 @@ export default function TextCleanerPage() {
               <h3 className="font-medium text-gray-300">Your Text</h3>
               <div className="flex items-center gap-2">
                 <span className="text-xs text-gray-400">{input.length.toLocaleString()} chars</span>
-                <MicButton textarea_ref={input_ref} value={input} on_change={set_input} />
+                <MicButton textarea_ref={input_ref} value={input} on_change={set_input} disabled={!!loading_action} />
               </div>
             </div>
             <textarea
@@ -440,9 +442,11 @@ export default function TextCleanerPage() {
                   >
                     Copy
                   </button>
+                  <MicButton textarea_ref={cleaned_ref} value={cleaned} on_change={set_cleaned} disabled={!!loading_action} />
                 </div>
               </div>
               <textarea
+                ref={cleaned_ref}
                 value={cleaned}
                 onChange={e => set_cleaned(e.target.value)}
                 className="w-full p-4 font-mono text-sm resize-none focus:outline-none bg-transparent text-gray-200"
@@ -475,9 +479,11 @@ export default function TextCleanerPage() {
                   >
                     Copy
                   </button>
+                  <MicButton textarea_ref={story_ref} value={story} on_change={set_story} disabled={!!loading_action} />
                 </div>
               </div>
               <textarea
+                ref={story_ref}
                 value={story}
                 onChange={e => set_story(e.target.value)}
                 className="w-full p-4 font-mono text-sm resize-none focus:outline-none bg-transparent text-gray-200"

--- a/src/app/tools/instruction-stripper/page.tsx
+++ b/src/app/tools/instruction-stripper/page.tsx
@@ -5,8 +5,9 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 
 export default function InstructionStripperPage() {
   const [input, set_input] = useState('');
@@ -15,6 +16,7 @@ export default function InstructionStripperPage() {
   const [error, set_error] = useState<string | null>(null);
   const [copy_status, set_copy_status] = useState<string | null>(null);
   const [usage, set_usage] = useState<{ input_tokens: number; output_tokens: number } | null>(null);
+  const input_ref = useRef<HTMLTextAreaElement>(null);
 
   const strip = async () => {
     if (!input.trim()) return;
@@ -90,9 +92,13 @@ export default function InstructionStripperPage() {
           <div className="bg-white/5 rounded-xl border border-white/10 overflow-hidden">
             <div className="bg-white/5 px-4 py-2 border-b border-white/10 flex justify-between items-center">
               <h3 className="font-medium text-gray-300">Paste AI Output</h3>
-              <span className="text-xs text-gray-400">{input.length.toLocaleString()} chars</span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400">{input.length.toLocaleString()} chars</span>
+                <MicButton textarea_ref={input_ref} value={input} on_change={set_input} disabled={loading} />
+              </div>
             </div>
             <textarea
+              ref={input_ref}
               value={input}
               onChange={e => set_input(e.target.value)}
               placeholder={`Paste the AI response here. For example:\n\nHere's a prompt for VS Code AI chat:\n\n---\n\nAudit: Session Initialization Flow\n\nTrace the exact sequence of operations...\n\n---\n\nPaste that into VS Code AI chat and bring the results back here.`}

--- a/src/app/tools/knowledge-diff/page.tsx
+++ b/src/app/tools/knowledge-diff/page.tsx
@@ -6,8 +6,9 @@
  * Two-step flow: analyze for losses, then generate appendix if needed
  */
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 
 interface UsageInfo {
   analysis_input: number;
@@ -32,6 +33,8 @@ export default function KnowledgeDiffPage() {
   const [result, set_result] = useState<DiffResult | null>(null);
   const [error, set_error] = useState('');
   const [copied, set_copied] = useState(false);
+  const old_doc_ref = useRef<HTMLTextAreaElement>(null);
+  const new_doc_ref = useRef<HTMLTextAreaElement>(null);
 
   async function api_call(body: Record<string, unknown>) {
     const response = await fetch('/api/knowledge-diff', {
@@ -176,15 +179,14 @@ export default function KnowledgeDiffPage() {
         }}>
           {/* Old Document */}
           <div>
-            <label style={{
-              display: 'block',
-              marginBottom: '8px',
-              fontWeight: 500,
-              color: '#ccc'
-            }}>
-              OLD Document
-            </label>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+              <label style={{ fontWeight: 500, color: '#ccc' }}>
+                OLD Document
+              </label>
+              <MicButton textarea_ref={old_doc_ref} value={old_doc} on_change={set_old_doc} disabled={!!status} />
+            </div>
             <textarea
+              ref={old_doc_ref}
               value={old_doc}
               onChange={(e) => set_old_doc(e.target.value)}
               placeholder="Paste your original/old knowledge document here..."
@@ -208,15 +210,14 @@ export default function KnowledgeDiffPage() {
 
           {/* New Document */}
           <div>
-            <label style={{
-              display: 'block',
-              marginBottom: '8px',
-              fontWeight: 500,
-              color: '#ccc'
-            }}>
-              NEW Document
-            </label>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+              <label style={{ fontWeight: 500, color: '#ccc' }}>
+                NEW Document
+              </label>
+              <MicButton textarea_ref={new_doc_ref} value={new_doc} on_change={set_new_doc} disabled={!!status} />
+            </div>
             <textarea
+              ref={new_doc_ref}
               value={new_doc}
               onChange={(e) => set_new_doc(e.target.value)}
               placeholder="Paste your updated/new knowledge document here..."

--- a/src/app/tools/markdown/page.tsx
+++ b/src/app/tools/markdown/page.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 
 export default function MarkdownConverterPage() {
   const [markdown_content, set_markdown_content] = useState('');
@@ -233,9 +234,9 @@ export default function MarkdownConverterPage() {
     }
   };
 
-  // Handle markdown changes
-  const handle_markdown_change = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const markdown = e.target.value;
+  // Apply a new markdown value and re-sync the rich editor preview.
+  // Used by both the textarea onChange and the MicButton dictation path.
+  const apply_markdown = (markdown: string) => {
     set_markdown_content(markdown);
 
     if (!is_updating_from_rich) {
@@ -253,6 +254,10 @@ export default function MarkdownConverterPage() {
         }
       }, 300);
     }
+  };
+
+  const handle_markdown_change = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    apply_markdown(e.target.value);
   };
 
   // Apply formatting
@@ -440,7 +445,7 @@ export default function MarkdownConverterPage() {
           <div className="bg-white/5 rounded-xl border border-white/10 overflow-hidden min-w-0">
             <div className="bg-white/5 px-4 py-2 border-b border-white/10 flex justify-between items-center">
               <h3 className="font-medium text-gray-300">Markdown</h3>
-              <div className="flex flex-col sm:flex-row gap-2">
+              <div className="flex flex-col sm:flex-row gap-2 items-center">
                 <button
                   onClick={copy_markdown}
                   className="px-3 py-2 sm:py-1 bg-[#333] sm:bg-white/10 hover:bg-cyan-400/20 rounded border border-[#555] sm:border-white/20 text-sm text-gray-300 transition-all"
@@ -455,6 +460,7 @@ export default function MarkdownConverterPage() {
                 >
                   Clear
                 </button>
+                <MicButton textarea_ref={markdown_textarea_ref} value={markdown_content} on_change={apply_markdown} />
               </div>
             </div>
 

--- a/src/app/tools/prompt-library/page.tsx
+++ b/src/app/tools/prompt-library/page.tsx
@@ -5,8 +5,9 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import MicButton from '@/components/mic_button';
 
 interface Prompt {
   id: string;
@@ -45,6 +46,8 @@ export default function PromptLibraryPage() {
   const [active_prompt, set_active_prompt] = useState<Prompt | null>(null);
   const [versions, set_versions] = useState<PromptVersion[]>([]);
   const [editor_content, set_editor_content] = useState('');
+  const editor_ref = useRef<HTMLTextAreaElement>(null);
+  const notes_ref = useRef<HTMLTextAreaElement>(null);
   const [saving, set_saving] = useState(false);
   const [show_history, set_show_history] = useState(false);
   const [viewing_version, set_viewing_version] = useState<PromptVersion | null>(null);
@@ -610,6 +613,7 @@ export default function PromptLibraryPage() {
         ) : (
           <div className="mb-4">
             <textarea
+              ref={editor_ref}
               value={editor_content}
               onChange={(e) => set_editor_content(e.target.value)}
               placeholder="Write your prompt here..."
@@ -617,7 +621,10 @@ export default function PromptLibraryPage() {
             />
             <div className="flex items-center justify-between mt-1">
               <span className="text-xs text-gray-400">{editor_content.length.toLocaleString()} characters</span>
-              {has_unsaved && <span className="text-xs text-amber-400">Unsaved changes</span>}
+              <div className="flex items-center gap-2">
+                {has_unsaved && <span className="text-xs text-amber-400">Unsaved changes</span>}
+                <MicButton textarea_ref={editor_ref} value={editor_content} on_change={set_editor_content} />
+              </div>
             </div>
           </div>
         )}
@@ -638,9 +645,15 @@ export default function PromptLibraryPage() {
                 >
                   {saving_notes ? 'Saving...' : 'Save notes'}
                 </button>
+                <MicButton
+                  textarea_ref={notes_ref}
+                  value={prompt_notes}
+                  on_change={(next) => { set_prompt_notes(next); set_notes_saved(false); }}
+                />
               </div>
             </div>
             <textarea
+              ref={notes_ref}
               value={prompt_notes}
               onChange={(e) => { set_prompt_notes(e.target.value); set_notes_saved(false); }}
               onBlur={handle_save_notes}

--- a/src/components/mic_button.tsx
+++ b/src/components/mic_button.tsx
@@ -48,9 +48,10 @@ interface Props {
   on_change: (next: string) => void;
   lang?: string;
   className?: string;
+  disabled?: boolean;
 }
 
-export default function MicButton({ textarea_ref, value, on_change, lang = 'en-US', className }: Props) {
+export default function MicButton({ textarea_ref, value, on_change, lang = 'en-US', className, disabled = false }: Props) {
   const [supported] = useState(() => !!get_recognition_ctor());
   const [phase, set_phase] = useState<Phase>('idle');
   const [status_text, set_status_text] = useState('');
@@ -65,6 +66,18 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
 
   useEffect(() => { value_ref.current = value; }, [value]);
   useEffect(() => { on_change_ref.current = on_change; }, [on_change]);
+
+  // When the parent disables the mic mid-recording (e.g. a generation
+  // request kicks off), abort any active session so transcripts can't
+  // clobber the soon-to-be-replaced textarea value.
+  useEffect(() => {
+    if (!disabled) return;
+    wants_recording_ref.current = false;
+    const rec = recognition_ref.current;
+    if (rec) {
+      try { rec.abort(); } catch { /* ignore */ }
+    }
+  }, [disabled]);
 
   const clear_watchdog = useCallback(() => {
     if (startup_watchdog_ref.current !== null) {
@@ -183,7 +196,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
   }, [lang, clear_watchdog, insert_transcript]);
 
   async function handle_click() {
-    if (!supported) return;
+    if (!supported || disabled) return;
     if (phase === 'starting' || phase === 'stopping') return;
 
     const recognition = recognition_ref.current;
@@ -305,7 +318,7 @@ export default function MicButton({ textarea_ref, value, on_change, lang = 'en-U
       <button
         type="button"
         onClick={handle_click}
-        disabled={!supported}
+        disabled={!supported || disabled}
         title={title}
         aria-label={recording ? 'Stop voice input' : 'Start voice input'}
         aria-pressed={recording}


### PR DESCRIPTION
Partial #209 — textarea rollout only. Phase 2 (Whisper backend) deliberately left for a separate effort.

## Summary

- Wires `<MicButton>` into every remaining free-text textarea surveyed for #195. Same component, same caret/selection-aware insertion.
- Adds an optional `disabled` prop to MicButton so parents can shut down dictation while a generation request is in flight (regen-clobber concern from #209).

## Changes

**Shared component**
- `src/components/mic_button.tsx` — new `disabled?: boolean` prop. An effect keyed on `disabled` aborts any active recognition session when the parent flips it true. `handle_click` and the rendered `<button disabled>` both honour the prop.

**Wirings**
- `/creative/text-cleaner` — `cleaned` and `story` output textareas, both `disabled={!!loading_action}`. Existing `input` mic also gains the same guard for consistency (clear/clean reset paths).
- `/creative/edit/[id]` — `story-blurb` and `story-html`.
- `/tools/markdown` — markdown editor. Extracted `apply_markdown(string)` helper so dictated text re-syncs the rich-editor preview the same way typed text does (debounced markdown→HTML pass). `handle_markdown_change` now thinly wraps the helper.
- `/tools/prompt-library` — main prompt editor (in the char-count footer) and notes textarea (in the existing header). Notes mic also flips `set_notes_saved(false)` like the textarea onChange does.
- `/tools/instruction-stripper` — input textarea, `disabled={loading}`.
- `/tools/knowledge-diff` — both OLD and NEW doc textareas, `disabled={!!status}`.

## Lint / build

Could not run `npm run lint -- --max-warnings 0` or `npm run build` locally — sandbox blocks `npm install` (`403 Forbidden` on `registry.npmjs.org`). Vercel CI on this PR is the verification path. The same ESLint patterns Bill called out (forward-declared functions in `useEffect`, `setState` inside effects) were checked manually:

- New `disabled` effect uses only refs and immediate side effects, no setState, no forward-declared functions.
- All new imports are used.
- All new refs are wired to their textarea via `ref={...}`.

If lint flags anything, ping me and I'll fix on this branch.

## Test plan

For each page (Chrome with mic permission already granted):

- [ ] `/creative/text-cleaner`: click mic on each of the three textareas, dictate, confirm caret-aware insert. Trigger "Clean Up" / "Turn Into Story" — confirm any active mic stops mid-dictation and disables until the action settles.
- [ ] `/creative/edit/[id]/...`: dictate into Blurb and Story HTML; confirm the live preview re-renders.
- [ ] `/tools/markdown`: dictate into Markdown side; confirm rich-editor preview updates after the 300ms debounce.
- [ ] `/tools/prompt-library`: dictate into editor (footer mic) and notes (header mic); confirm "Unsaved" indicator triggers.
- [ ] `/tools/instruction-stripper`: dictate into input; click "Strip" and confirm mic is disabled while loading.
- [ ] `/tools/knowledge-diff`: dictate into OLD and NEW; click "Compare" and confirm both mics disable until done.

## Out of scope

- Phase 2 (OpenAI Whisper backend) — separate effort, see #209.

https://claude.ai/code/session_0124ECFBg1i4s3EnzDGP7Cmw

---
_Generated by [Claude Code](https://claude.ai/code/session_0124ECFBg1i4s3EnzDGP7Cmw)_