### PR TITLE
Fix story generation: resilient XML parsing #207

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -158,8 +158,7 @@ ${formatted_posts}`;
         }
       ],
       messages: [
-        { role: 'user', content: user_message },
-        { role: 'assistant', content: '<response>\n<story>' }
+        { role: 'user', content: user_message }
       ]
     });
 
@@ -168,7 +167,7 @@ ${formatted_posts}`;
       throw new Error('Unexpected response type');
     }
 
-    const response_text = '<response>\n<story>' + stripCodeFences(content.text);
+    const response_text = stripCodeFences(content.text);
     const story = extractTagContent(response_text, 'story');
 
     if (!story) {

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -195,9 +195,10 @@ ${formatted_posts}`;
 
   } catch (error) {
     console.error('Generate error:', error);
-    const is_prod = process.env.NODE_ENV === 'production';
+    const msg = error instanceof Error ? error.message : String(error);
+    const name = error instanceof Error ? error.constructor.name : 'Unknown';
     return NextResponse.json(
-      { error: is_prod ? 'Failed to generate story' : (error instanceof Error ? error.message : 'Failed to generate story') },
+      { error: `[${name}] ${msg}` },
       { status: 500 }
     );
   }

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -21,15 +21,26 @@ function stripCodeFences(text: string): string {
   return cleaned.trim();
 }
 
-function extractTagContent(response: string, tag: string): string {
+function extractTagContent(response: string, tag: string): string | null {
   const pattern = new RegExp(`<${tag}>\\s*([\\s\\S]*?)\\s*<\\/${tag}>`, 'i');
   const match = response.match(pattern);
 
   if (!match || !match[1]) {
-    throw new Error(`Missing <${tag}> in model response`);
+    return null;
   }
 
   return match[1].trim();
+}
+
+function blurbFromStory(story_html: string): string {
+  const text = story_html
+    .replace(/<h2[^>]*>.*?<\/h2>/gi, '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
+  return sentences.slice(0, 2).join(' ').trim().substring(0, 300);
 }
 
 export async function POST(request: NextRequest) {
@@ -147,7 +158,8 @@ ${formatted_posts}`;
         }
       ],
       messages: [
-        { role: 'user', content: user_message }
+        { role: 'user', content: user_message },
+        { role: 'assistant', content: '<response>\n<story>' }
       ]
     });
 
@@ -156,16 +168,18 @@ ${formatted_posts}`;
       throw new Error('Unexpected response type');
     }
 
-    const response_text = stripCodeFences(content.text);
+    const response_text = '<response>\n<story>' + stripCodeFences(content.text);
     const story = extractTagContent(response_text, 'story');
-    const blurb = extractTagContent(response_text, 'blurb')
+
+    if (!story) {
+      throw new Error('Missing <story> in model response');
+    }
+
+    const raw_blurb = extractTagContent(response_text, 'blurb');
+    const blurb = (raw_blurb || blurbFromStory(story))
       .replace(/<[^>]*>/g, '')
       .replace(/\s+/g, ' ')
       .trim();
-
-    if (!story || !blurb) {
-      throw new Error('Incomplete model response');
-    }
 
     // Save story to database and get shareable ID
     const date_key = `${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
@@ -195,10 +209,9 @@ ${formatted_posts}`;
 
   } catch (error) {
     console.error('Generate error:', error);
-    const msg = error instanceof Error ? error.message : String(error);
-    const name = error instanceof Error ? error.constructor.name : 'Unknown';
+    const msg = error instanceof Error ? error.message : 'Failed to generate story';
     return NextResponse.json(
-      { error: `[${name}] ${msg}` },
+      { error: msg },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- Sonnet 4.6 inconsistently omits `<blurb>` tags in story generation responses
- Added fallback that derives blurb from story text when tag is missing
- Error messages now show actual cause instead of generic "Failed to generate story"

Closes #207

## Test plan
- [x] Generate story on preview — confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)