### PR TITLE
Remove 3-paragraph constraint from Substack generation

### DIFF
--- a/src/app/api/clean-text/route.ts
+++ b/src/app/api/clean-text/route.ts
@@ -40,14 +40,10 @@ export async function POST(request: NextRequest) {
     const { content, mode } = body;
 
     if (mode === 'substack') {
-      const { opening_scene, current_situation, outcome, images } = body;
+      const { story_text, images } = body;
 
-      if (
-        !opening_scene || typeof opening_scene !== 'string' || !opening_scene.trim() ||
-        !current_situation || typeof current_situation !== 'string' || !current_situation.trim() ||
-        !outcome || typeof outcome !== 'string' || !outcome.trim()
-      ) {
-        return NextResponse.json({ error: 'opening_scene, current_situation, and outcome are required' }, { status: 400 });
+      if (!story_text || typeof story_text !== 'string' || !story_text.trim()) {
+        return NextResponse.json({ error: 'story_text is required' }, { status: 400 });
       }
 
       if (images !== undefined) {
@@ -62,21 +58,13 @@ export async function POST(request: NextRequest) {
 
       const client = new Anthropic({ apiKey: api_key });
 
-      const prompt_text = `You will be acting as a creative story generator that helps users transform their experiences into engaging narratives.
+      const prompt_text = `You will be acting as a creative story generator that helps users transform their experiences into engaging Substack narratives.
 
-## Direct Mode: Pre-Provided Inputs
+## Story Input
 
-<opening_scene>
-${opening_scene}
-</opening_scene>
-
-<current_situation>
-${current_situation}
-</current_situation>
-
-<outcome>
-${outcome}
-</outcome>
+<story>
+${story_text.trim()}
+</story>
 
 <images>
 ${images && images.length > 0 ? 'See the images attached above in this message.' : 'No images provided.'}
@@ -84,12 +72,11 @@ ${images && images.length > 0 ? 'See the images attached above in this message.'
 
 ## Story Generation Instructions
 
-Generate a story following these guidelines:
+Transform the story above into a polished Substack post following these guidelines:
 
 **Narrative Structure:**
-- Begin with vivid, high-energy storytelling of the opening scene from the past experience. Leave the outcome partly open-ended to create suspense.
-- Transition naturally to the current situation, showing contrast between past and present.
-- Connect the past and present by showing how the earlier outcome offers insight, hope, or a lesson for the current challenge.
+- Preserve the author's structure and flow — do not reorganize or impose a different paragraph count.
+- Enhance the storytelling with vivid detail, natural pacing, and emotional resonance.
 - Write as one continuous narrative with no section headers or breaks.
 
 **Style Calibration:**

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -256,12 +256,6 @@ export default function TextCleanerPage() {
   const generate_substack = async () => {
     if (!story.trim()) return;
 
-    const paragraphs = story.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean);
-    if (paragraphs.length !== 3) {
-      set_error('Story must contain exactly 3 paragraphs separated by blank lines');
-      return;
-    }
-
     set_loading_action('substack');
     set_error(null);
     set_substack('');
@@ -275,9 +269,7 @@ export default function TextCleanerPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           mode: 'substack',
-          opening_scene: paragraphs[0],
-          current_situation: paragraphs[1],
-          outcome: paragraphs[2],
+          story_text: story.trim(),
           images: resized,
         }),
       });
@@ -311,7 +303,7 @@ export default function TextCleanerPage() {
           What Am I Trying To Say
         </h1>
         <p className="text-center text-gray-400 mb-8">
-          Clean up your ramble, then turn it into a three-paragraph story
+          Clean up your ramble, then turn it into a story
         </p>
 
         {/* Copy toast */}


### PR DESCRIPTION
## Summary
- Removes the hard 3-paragraph validation from the Substack story generation step (#216)
- API now accepts a single `story_text` field instead of `opening_scene`/`current_situation`/`outcome`
- Prompt updated to preserve the author's structure rather than imposing paragraph count

## Test plan
- [x] Tested on preview: multi-paragraph story successfully generates Substack post
- [x] Build and lint pass

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)