### PR TITLE
Improve F1 reveal error message when results not yet available

### DIFF
--- a/src/lib/f1/jolpica.ts
+++ b/src/lib/f1/jolpica.ts
@@ -101,7 +101,7 @@ export class JolpicaAdapter implements F1DataAdapter {
     const race = data.RaceTable?.Races?.[0];
 
     if (!race) {
-      throw new Error(`No results found for ${season} round ${round} ${session_type}`);
+      throw new Error(`Results not yet available for ${season} round ${round} ${session_type} — the F1 data API may still be processing. Try again in a couple of hours.`);
     }
 
     if (session_type === 'sprint_qualifying') {


### PR DESCRIPTION
## Summary
- Replaces the cryptic `"No results found for..."` error with a clear message explaining the F1 data API may still be processing and to try again in a couple of hours

## What to test
After merging, if you reveal before Jolpica has the data, the alert will say:
> "Results not yet available for 2026 round X race — the F1 data API may still be processing. Try again in a couple of hours."

One-line change in `src/lib/f1/jolpica.ts`. No logic changes.

https://claude.ai/code/session_01LUPQqum6kXPr3AHDGFkK3H

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUPQqum6kXPr3AHDGFkK3H)_