### PR TITLE
Migrate Strava disconnect to oauth/revoke

### DIFF
--- a/src/app/api/strava/disconnect/route.ts
+++ b/src/app/api/strava/disconnect/route.ts
@@ -1,6 +1,6 @@
 /**
  * API route: DELETE /api/strava/disconnect
- * Deauthorizes the Strava token and removes all stored tokens/cache
+ * Revokes the Strava token (oauth/revoke) and removes all stored tokens/cache
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -20,16 +20,21 @@ export async function DELETE(request: NextRequest) {
   try {
     const tokens = await get_strava_tokens();
 
-    // Deauthorize on Strava's side so the token is fully revoked
+    // Revoke on Strava's side so the token is fully invalidated.
+    // Uses oauth/revoke (oauth/deauthorize is retired June 1, 2027).
     if (tokens) {
       try {
-        await fetch(
-          `https://www.strava.com/oauth/deauthorize?access_token=${tokens.access_token}`,
-          { method: 'POST' }
-        );
+        const revoke_res = await fetch('https://www.strava.com/oauth/revoke', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ access_token: tokens.access_token }),
+        });
+        if (!revoke_res.ok) {
+          console.warn('Strava revoke returned non-OK:', revoke_res.status, await revoke_res.text());
+        }
       } catch (err) {
         // Log but don't block local cleanup
-        console.warn('Strava deauthorize call failed:', err);
+        console.warn('Strava revoke call failed:', err);
       }
     }
 


### PR DESCRIPTION
## Summary

Replaces the retired `oauth/deauthorize` call in `/api/strava/disconnect` with `oauth/revoke`, which is live now and will be the only option after June 1, 2027.

Also surfaces non-OK responses in the warning log — the old call was failing silently, which meant tokens weren't actually being revoked on Strava's side when users hit Disconnect.

## Scope

One file: `src/app/api/strava/disconnect/route.ts`.

## Before merging

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Smoke test on Vercel preview: connect on `/health/strava`, hit Disconnect, confirm Strava returns 200 and reconnecting requires the full consent screen again (proves the token was actually revoked server-side, not just locally forgotten)

## Context

Part of the June 2026 Strava API audit. The larger work — migrating the API v3 base URL to `api-v3.strava.com` — is tracked separately in #223 and isn't urgent until 2027.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL3Rjt4heSSFyEiCRB6F1k)_