### PR TITLE
Fix coaching save session crash (NaN/Infinity in DB args)

### DIFF
--- a/src/app/api/coaching/trends/today/route.ts
+++ b/src/app/api/coaching/trends/today/route.ts
@@ -34,12 +34,18 @@ export async function POST(request: NextRequest) {
       });
 
       if (existing.rows.length === 0) {
+        const fin = (v: number | null | undefined): number | null =>
+          v != null && isFinite(v) ? v : null;
+
         // Estimate CV age from HRV + RHR if not provided directly
-        let cv_age = liveMetrics.cardiovascular_age ?? null;
-        if (cv_age == null && liveMetrics.hrv_rmssd != null && liveMetrics.resting_hr != null) {
-          const hrv_age = 107 - (12.5 * Math.log(liveMetrics.hrv_rmssd));
-          const rhr_age = 1.4 * liveMetrics.resting_hr - 40;
-          cv_age = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+        let cv_age = fin(liveMetrics.cardiovascular_age);
+        const hrv = fin(liveMetrics.hrv_rmssd);
+        const rhr = fin(liveMetrics.resting_hr);
+        if (cv_age == null && hrv != null && hrv > 0 && rhr != null) {
+          const hrv_age = 107 - (12.5 * Math.log(hrv));
+          const rhr_age = 1.4 * rhr - 40;
+          const est = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+          if (isFinite(est)) cv_age = est;
         }
 
         await db.execute({
@@ -50,16 +56,10 @@ export async function POST(request: NextRequest) {
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           args: [
             today,
-            liveMetrics.sleep_duration_min ?? null,
-            liveMetrics.sleep_efficiency_pct ?? null,
-            liveMetrics.deep_sleep_min ?? null,
-            liveMetrics.rem_sleep_min ?? null,
-            liveMetrics.hrv_rmssd ?? null,
-            liveMetrics.resting_hr ?? null,
-            liveMetrics.readiness_score ?? null,
-            cv_age,
-            liveMetrics.spo2_average ?? null,
-            liveMetrics.weight_lbs ?? null,
+            fin(liveMetrics.sleep_duration_min), fin(liveMetrics.sleep_efficiency_pct),
+            fin(liveMetrics.deep_sleep_min), fin(liveMetrics.rem_sleep_min),
+            hrv, rhr, fin(liveMetrics.readiness_score), cv_age, fin(liveMetrics.spo2_average),
+            fin(liveMetrics.weight_lbs),
             now, now,
           ],
         });

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -267,10 +267,12 @@ export default function CoachPage() {
         }
 
         // Estimate cardiovascular age from HRV + RHR (Umetani regression)
-        if (m.hrv && m.resting_hr) {
+        // hrv must be > 0 — Math.log(0) = -Infinity
+        if (m.hrv && m.hrv > 0 && m.resting_hr) {
           const hrv_age = 107 - (12.5 * Math.log(m.hrv));
           const rhr_age = 1.4 * m.resting_hr - 40;
-          m.cv_age = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+          const estimated = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+          if (isFinite(estimated)) m.cv_age = estimated;
         }
 
         if (stravaActivities.length > 0) {

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -244,13 +244,16 @@ export async function build_data_injection(
     if (cv_age?.vascular_age) {
       lines.push(`Cardiovascular age: ${cv_age.vascular_age}`);
       metrics.cv_age = cv_age.vascular_age;
-    } else if (hrv_val && rhr_val) {
+    } else if (hrv_val && hrv_val > 0 && rhr_val) {
       // Estimate CV age from HRV + RHR (Umetani regression)
+      // hrv_val must be > 0 — Math.log(0) = -Infinity
       const hrv_age = 107 - (12.5 * Math.log(hrv_val));
       const rhr_age = 1.4 * rhr_val - 40;
       const estimated_cv_age = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
-      lines.push(`Cardiovascular age: ~${estimated_cv_age} (estimated from HRV + RHR)`);
-      metrics.cv_age = estimated_cv_age;
+      if (isFinite(estimated_cv_age)) {
+        lines.push(`Cardiovascular age: ~${estimated_cv_age} (estimated from HRV + RHR)`);
+        metrics.cv_age = estimated_cv_age;
+      }
     }
 
     if (stress) {

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -212,6 +212,10 @@ export interface InjectMetrics {
   restored_min?: number | null;
 }
 
+// Coerce NaN/Infinity to null so libSQL never receives a non-finite number
+const fin = (v: number | null | undefined): number | null =>
+  v != null && isFinite(v) ? v : null;
+
 export async function populate_daily_metrics(
   date_str: string,
   epoch_day: number,
@@ -320,11 +324,11 @@ export async function populate_daily_metrics(
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       epoch_day,
-      sleep_duration_min, sleep_efficiency_pct, deep_sleep_min, rem_sleep_min,
-      hrv_rmssd, resting_hr, readiness_score, cardiovascular_age, spo2_average,
-      vo2_max, training_load_acute, training_load_chronic, recovery_pct,
+      fin(sleep_duration_min), fin(sleep_efficiency_pct), fin(deep_sleep_min), fin(rem_sleep_min),
+      fin(hrv_rmssd), fin(resting_hr), fin(readiness_score), fin(cardiovascular_age), fin(spo2_average),
+      fin(vo2_max), fin(training_load_acute), fin(training_load_chronic), fin(recovery_pct),
       null, null, // zone2_min_weekly, vo2max_intervals_weekly — computed separately
-      manual?.weight_lbs ?? null, manual?.back_pain_scale ?? null,
+      fin(manual?.weight_lbs ?? null), fin(manual?.back_pain_scale ?? null),
       manual?.back_mobility_notes ?? null, manual?.bowel_status ?? null, manual?.injury_notes ?? null,
       now, now,
     ],

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -275,10 +275,12 @@ export async function populate_daily_metrics(
   }
 
   // Estimate CV age from HRV + RHR if Oura didn't provide it directly
-  if (cardiovascular_age == null && hrv_rmssd != null && resting_hr != null) {
+  // hrv_rmssd must be > 0 — Math.log(0) = -Infinity which poisons the INSERT
+  if (cardiovascular_age == null && hrv_rmssd != null && hrv_rmssd > 0 && resting_hr != null) {
     const hrv_age = 107 - (12.5 * Math.log(hrv_rmssd));
     const rhr_age = 1.4 * resting_hr - 40;
-    cardiovascular_age = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+    const estimated = Math.round(0.65 * hrv_age + 0.35 * rhr_age);
+    if (isFinite(estimated)) cardiovascular_age = estimated;
   }
 
   // Extract COROS fields


### PR DESCRIPTION
## Summary

- `Math.log(0)` returns `-Infinity` when HRV is zero, poisoning the cardiovascular age calculation and crashing the libSQL INSERT with "Only finite numbers can be passed as arguments"
- Same unguarded `Math.log` existed in 4 places: `db.ts`, `trends/today/route.ts`, `data-injection.ts`, and `coach/page.tsx`
- COROS `Number()` coercions and cached Oura data could also produce NaN reaching the INSERT

## Fix

Added a `fin()` helper that converts NaN/Infinity → null, applied to every numeric arg in both DB INSERT statements. All four `Math.log` call sites now guard `hrv > 0` before calling.

## Test

Open `/coach`, let it load, click **Save Session** — should save without error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaMe5Pnt6x7tEivhbq7gDW)_