### PR TITLE
Add image URL editing to story editor

### DIFF
--- a/src/app/api/story/[id]/route.ts
+++ b/src/app/api/story/[id]/route.ts
@@ -21,6 +21,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     const body = await request.json();
     const content = typeof body.content === 'string' ? body.content.trim() : '';
     const blurb = typeof body.blurb === 'string' ? body.blurb.trim() : body.blurb === null ? null : undefined;
+    const image_url = typeof body.image_url === 'string' ? body.image_url.trim() || null : body.image_url === null ? null : undefined;
 
     if (!content) {
       return NextResponse.json(
@@ -29,7 +30,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       );
     }
 
-    const story = await update_story(id, content, blurb);
+    const story = await update_story(id, content, blurb, image_url);
 
     if (!story) {
       return NextResponse.json(

--- a/src/app/creative/edit/[id]/editor_client.tsx
+++ b/src/app/creative/edit/[id]/editor_client.tsx
@@ -12,6 +12,7 @@ interface EditorStory {
   date_display: string;
   content: string;
   blurb: string | null;
+  image_url: string | null;
   edited_at: string | null;
 }
 
@@ -28,6 +29,8 @@ export default function StoryEditor({
 }: StoryEditorProps) {
   const [content, set_content] = useState(story.content);
   const [blurb, set_blurb] = useState(story.blurb || '');
+  const [image_url, set_image_url] = useState(story.image_url || '');
+  const [image_failed, set_image_failed] = useState(false);
   const [audit, set_audit] = useState(initial_audit);
   const [audit_updated_at, set_audit_updated_at] = useState(initial_audit_updated_at);
   const [saving, set_saving] = useState(false);
@@ -52,6 +55,7 @@ export default function StoryEditor({
         body: JSON.stringify({
           content,
           blurb: blurb.trim() || null,
+          image_url: image_url.trim() || null,
         }),
       });
 
@@ -177,6 +181,48 @@ export default function StoryEditor({
                 className="mb-5 min-h-24 w-full rounded-2xl border border-white/10 bg-[#0b1220] px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-300/50"
                 spellCheck={false}
               />
+              <label className="mb-2 block text-sm text-slate-300" htmlFor="story-image-url">
+                Image URL
+              </label>
+              <div className="mb-5 flex gap-2">
+                <input
+                  id="story-image-url"
+                  type="url"
+                  value={image_url}
+                  onChange={(event) => {
+                    set_image_url(event.target.value);
+                    set_image_failed(false);
+                  }}
+                  placeholder="https://…"
+                  className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-[#0b1220] px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-300/50"
+                  spellCheck={false}
+                />
+                {image_url && (
+                  <button
+                    type="button"
+                    onClick={() => { set_image_url(''); set_image_failed(false); }}
+                    className="shrink-0 rounded-2xl border border-white/10 px-3 py-2 text-xs text-slate-400 transition hover:border-red-400/40 hover:text-red-300"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              {image_url && !image_failed && (
+                <div className="mb-5 overflow-hidden rounded-2xl border border-white/10">
+                  <img
+                    src={image_url}
+                    alt="Story image preview"
+                    referrerPolicy="no-referrer"
+                    className="w-full object-cover"
+                    onError={() => set_image_failed(true)}
+                  />
+                </div>
+              )}
+              {image_url && image_failed && (
+                <p className="mb-5 rounded-2xl border border-amber-400/20 bg-amber-400/5 px-4 py-3 text-xs text-amber-300">
+                  Image failed to load — the URL may be invalid or hotlink-protected.
+                </p>
+              )}
               <div className="mb-3 flex items-center justify-between">
                 <label className="block text-sm text-slate-300" htmlFor="story-html">
                   Story HTML

--- a/src/app/creative/edit/[id]/page.tsx
+++ b/src/app/creative/edit/[id]/page.tsx
@@ -31,6 +31,7 @@ export default async function CreativeEditPage({ params }: PageProps) {
         date_display: story.date_display,
         content: story.content,
         blurb: story.blurb,
+        image_url: story.image_url,
         edited_at: story.edited_at,
       }}
       initial_audit={audit_record?.audit || null}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -682,7 +682,8 @@ export async function get_story(id: string): Promise<Story | null> {
 export async function update_story(
   id: string,
   content: string,
-  blurb?: string | null
+  blurb?: string | null,
+  image_url?: string | null
 ): Promise<Story | null> {
   await ensure_schema();
   const db = get_client();
@@ -695,10 +696,15 @@ export async function update_story(
   await db.execute({
     sql: `
       UPDATE stories
-      SET content = ?, blurb = ?, edited_at = CURRENT_TIMESTAMP
+      SET content = ?, blurb = ?, image_url = ?, edited_at = CURRENT_TIMESTAMP
       WHERE id = ?
     `,
-    args: [content, blurb === undefined ? existing.blurb : blurb, id]
+    args: [
+      content,
+      blurb === undefined ? existing.blurb : blurb,
+      image_url === undefined ? existing.image_url : image_url,
+      id,
+    ]
   });
 
   return get_story(id);


### PR DESCRIPTION
## Summary

- Adds an **Image URL** field to the story editor (below Blurb) with live preview and a Clear button
- Threads `image_url` through `update_story()` in `db.ts`, the `PATCH /api/story/[id]` route, and the editor client
- Saving with a blank URL clears the image; leaving the field unchanged keeps the existing URL

## Files changed

- `src/lib/db.ts` — `update_story()` accepts optional `image_url` (undefined = no change, null = clear, string = update)
- `src/app/api/story/[id]/route.ts` — PATCH extracts and forwards `image_url`
- `src/app/creative/edit/[id]/page.tsx` — passes `image_url` to editor client
- `src/app/creative/edit/[id]/editor_client.tsx` — Image URL input with live preview and error handling

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiyHfCHL9hg1Pg3oGhGGxv)_