### PR TITLE
Fix recurring story generation truncation (max_tokens 1024 to 8192)

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -149,7 +149,7 @@ ${formatted_posts}`;
 
     const message = await client.messages.create({
       model: MODELS.STORY_GENERATION,
-      max_tokens: 1024,
+      max_tokens: 8192,
       system: [
         {
           type: 'text',


### PR DESCRIPTION
## Problem
"Generate Story" fails with `Missing <story> in model response` on dates with many posts (e.g. June 24, 13 posts).

## Root cause
`max_tokens` was `1024`, a scaffold default present since the initial commit, never a deliberate choice. Long stories truncate before the closing `</story>` tag, so XML parsing returns null. The May 7 fix (#207/#211) misread the same truncation as "Sonnet omits `<blurb>`" and patched the symptom.

## Fix
Raise `max_tokens` to `8192`. It is a ceiling, not a cost (billed only for tokens generated), so this clears every realistic date with no downside.

## Test
- Build and lint pass
- On the preview: `/creative` -> June 24 -> Generate Story. Expected: full story with all 13 links, no error box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)