### PR TITLE
Fix error visibility and retain work on failure in text cleaner

### DIFF
--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -343,6 +343,14 @@ export default function TextCleanerPage() {
           </div>
         )}
 
+        {/* Error toast — fixed so it's visible regardless of scroll position */}
+        {error && (
+          <div role="alert" className="fixed top-4 left-4 right-4 sm:right-auto sm:max-w-sm bg-red-900/90 border border-red-500/50 rounded-lg px-4 py-3 text-red-200 text-sm shadow-xl z-50 flex items-center gap-3">
+            <span className="flex-1">{error}</span>
+            <button onClick={() => set_error(null)} aria-label="Dismiss error" className="text-red-300/60 hover:text-red-200 transition-colors shrink-0">✕</button>
+          </div>
+        )}
+
         {/* Confirm delete modal */}
         {confirm_delete_id && (
           <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
@@ -416,14 +424,6 @@ export default function TextCleanerPage() {
               >
                 View saved notes ({notes.length})
               </button>
-            </div>
-          )}
-
-          {/* Error */}
-          {error && (
-            <div role="alert" className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-400 text-sm flex items-center justify-between gap-3">
-              <span>{error}</span>
-              <button onClick={() => set_error(null)} aria-label="Dismiss error" className="text-red-400/60 hover:text-red-400 transition-colors shrink-0">✕</button>
             </div>
           )}
 

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -5,7 +5,7 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
 
 interface TextNote {
@@ -30,6 +30,7 @@ export default function TextCleanerPage() {
   const [notes, set_notes] = useState<TextNote[]>([]);
   const [confirm_delete_id, set_confirm_delete_id] = useState<string | null>(null);
   const [confirm_delete_context, set_confirm_delete_context] = useState<'copy' | 'story' | null>(null);
+  const hydrated = useRef(false);
   const fetch_notes = useCallback(async () => {
     try {
       const res = await fetch('/api/text-notes');
@@ -52,15 +53,37 @@ export default function TextCleanerPage() {
     return () => clearTimeout(t);
   }, [error]);
 
+  // Save to localStorage after hydration (hydrated guard prevents overwriting saved data on first render)
+  useEffect(() => {
+    if (!hydrated.current) return;
+    const has_content = input || cleaned || story;
+    if (has_content) {
+      localStorage.setItem('waits_v', '1');
+      if (input) localStorage.setItem('waits_input', input); else localStorage.removeItem('waits_input');
+      if (cleaned) localStorage.setItem('waits_cleaned', cleaned); else localStorage.removeItem('waits_cleaned');
+      if (story) localStorage.setItem('waits_story', story); else localStorage.removeItem('waits_story');
+    } else {
+      ['waits_v', 'waits_input', 'waits_cleaned', 'waits_story'].forEach(k => localStorage.removeItem(k));
+    }
+  }, [input, cleaned, story]);
+
+  // Restore from localStorage on mount; version key guards against stale schema
+  useEffect(() => {
+    if (localStorage.getItem('waits_v') !== '1') { hydrated.current = true; return; }
+    const saved_input   = localStorage.getItem('waits_input');
+    const saved_cleaned = localStorage.getItem('waits_cleaned');
+    const saved_story   = localStorage.getItem('waits_story');
+    if (saved_input)   set_input(saved_input);
+    if (saved_cleaned) set_cleaned(saved_cleaned);
+    if (saved_story)   set_story(saved_story);
+    hydrated.current = true;
+  }, []);
+
   const clean = async () => {
     if (!input.trim()) return;
 
     set_loading_action('clean');
     set_error(null);
-    set_cleaned('');
-    set_story('');
-    set_clean_usage(null);
-    set_story_usage(null);
 
     try {
       const res = await fetch('/api/clean-text', {
@@ -78,6 +101,10 @@ export default function TextCleanerPage() {
 
       set_cleaned(data.cleaned);
       set_clean_usage(data.usage);
+      set_story('');
+      set_story_usage(null);
+      set_substack('');
+      set_substack_usage(null);
     } catch {
       set_error('Couldn\'t clean text — try again');
     } finally {
@@ -91,8 +118,6 @@ export default function TextCleanerPage() {
 
     set_loading_action('story');
     set_error(null);
-    set_story('');
-    set_story_usage(null);
 
     try {
       const res = await fetch('/api/clean-text', {
@@ -110,6 +135,8 @@ export default function TextCleanerPage() {
 
       set_story(data.story);
       set_story_usage(data.usage);
+      set_substack('');
+      set_substack_usage(null);
     } catch {
       set_error('Couldn\'t build story — try again');
     } finally {
@@ -203,10 +230,6 @@ export default function TextCleanerPage() {
 
   const handle_note_story = (note: TextNote) => {
     set_cleaned(note.content);
-    set_story('');
-    set_story_usage(null);
-    set_substack('');
-    set_substack_usage(null);
     window.scrollTo({ top: 0, behavior: 'smooth' });
     // Use setTimeout so the cleaned state is set before triggering story generation
     setTimeout(() => {
@@ -264,8 +287,6 @@ export default function TextCleanerPage() {
 
     set_loading_action('substack');
     set_error(null);
-    set_substack('');
-    set_substack_usage(null);
 
     try {
       const resized = await Promise.all(images.map(resize_image));

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -47,36 +47,39 @@ export default function TextCleanerPage() {
     fetch_notes();
   }, [fetch_notes]);
 
-  useEffect(() => {
-    if (!error) return;
-    const t = setTimeout(() => set_error(null), 6000);
-    return () => clearTimeout(t);
-  }, [error]);
-
   // Save to localStorage after hydration (hydrated guard prevents overwriting saved data on first render)
   useEffect(() => {
     if (!hydrated.current) return;
-    const has_content = input || cleaned || story;
-    if (has_content) {
-      localStorage.setItem('waits_v', '1');
-      if (input) localStorage.setItem('waits_input', input); else localStorage.removeItem('waits_input');
-      if (cleaned) localStorage.setItem('waits_cleaned', cleaned); else localStorage.removeItem('waits_cleaned');
-      if (story) localStorage.setItem('waits_story', story); else localStorage.removeItem('waits_story');
-    } else {
-      ['waits_v', 'waits_input', 'waits_cleaned', 'waits_story'].forEach(k => localStorage.removeItem(k));
+    try {
+      const has_content = input || cleaned || story;
+      if (has_content) {
+        localStorage.setItem('waits_v', '1');
+        if (input) localStorage.setItem('waits_input', input); else localStorage.removeItem('waits_input');
+        if (cleaned) localStorage.setItem('waits_cleaned', cleaned); else localStorage.removeItem('waits_cleaned');
+        if (story) localStorage.setItem('waits_story', story); else localStorage.removeItem('waits_story');
+      } else {
+        ['waits_v', 'waits_input', 'waits_cleaned', 'waits_story'].forEach(k => localStorage.removeItem(k));
+      }
+    } catch {
+      // localStorage unavailable (sandboxed iframe, private mode, quota) — persistence is best-effort
     }
   }, [input, cleaned, story]);
 
   // Restore from localStorage on mount; version key guards against stale schema
   useEffect(() => {
-    if (localStorage.getItem('waits_v') !== '1') { hydrated.current = true; return; }
-    const saved_input   = localStorage.getItem('waits_input');
-    const saved_cleaned = localStorage.getItem('waits_cleaned');
-    const saved_story   = localStorage.getItem('waits_story');
-    if (saved_input)   set_input(saved_input);
-    if (saved_cleaned) set_cleaned(saved_cleaned);
-    if (saved_story)   set_story(saved_story);
-    hydrated.current = true;
+    try {
+      if (localStorage.getItem('waits_v') !== '1') { hydrated.current = true; return; }
+      const saved_input   = localStorage.getItem('waits_input');
+      const saved_cleaned = localStorage.getItem('waits_cleaned');
+      const saved_story   = localStorage.getItem('waits_story');
+      if (saved_input)   set_input(saved_input);
+      if (saved_cleaned) set_cleaned(saved_cleaned);
+      if (saved_story)   set_story(saved_story);
+    } catch {
+      // localStorage unavailable — skip restore
+    } finally {
+      hydrated.current = true;
+    }
   }, []);
 
   const clean = async () => {

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -46,6 +46,12 @@ export default function TextCleanerPage() {
     fetch_notes();
   }, [fetch_notes]);
 
+  useEffect(() => {
+    if (!error) return;
+    const t = setTimeout(() => set_error(null), 6000);
+    return () => clearTimeout(t);
+  }, [error]);
+
   const clean = async () => {
     if (!input.trim()) return;
 
@@ -73,7 +79,7 @@ export default function TextCleanerPage() {
       set_cleaned(data.cleaned);
       set_clean_usage(data.usage);
     } catch {
-      set_error('Network error — try again');
+      set_error('Couldn\'t clean text — try again');
     } finally {
       set_loading_action(null);
     }
@@ -105,7 +111,7 @@ export default function TextCleanerPage() {
       set_story(data.story);
       set_story_usage(data.usage);
     } catch {
-      set_error('Network error — try again');
+      set_error('Couldn\'t build story — try again');
     } finally {
       set_loading_action(null);
     }
@@ -158,7 +164,7 @@ export default function TextCleanerPage() {
       set_copy_status('Note saved!');
       setTimeout(() => set_copy_status(null), 2000);
     } catch {
-      set_error('Network error — try again');
+      set_error('Couldn\'t save note — try again');
     } finally {
       set_loading_action(null);
     }
@@ -181,7 +187,7 @@ export default function TextCleanerPage() {
 
       await fetch_notes();
     } catch {
-      set_error('Network error — try again');
+      set_error('Couldn\'t delete note — try again');
     } finally {
       set_loading_action(null);
       set_confirm_delete_id(null);
@@ -279,7 +285,7 @@ export default function TextCleanerPage() {
       set_substack(data.substack);
       set_substack_usage(data.usage);
     } catch {
-      set_error('Network error — try again');
+      set_error('Couldn\'t generate Substack post — try again');
     } finally {
       set_loading_action(null);
     }
@@ -391,8 +397,9 @@ export default function TextCleanerPage() {
 
           {/* Error */}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-400 text-sm">
-              {error}
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-400 text-sm flex items-center justify-between gap-3">
+              <span>{error}</span>
+              <button onClick={() => set_error(null)} className="text-red-400/60 hover:text-red-400 transition-colors shrink-0">✕</button>
             </div>
           )}
 

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -418,9 +418,9 @@ export default function TextCleanerPage() {
 
           {/* Error */}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-400 text-sm flex items-center justify-between gap-3">
+            <div role="alert" className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-red-400 text-sm flex items-center justify-between gap-3">
               <span>{error}</span>
-              <button onClick={() => set_error(null)} className="text-red-400/60 hover:text-red-400 transition-colors shrink-0">✕</button>
+              <button onClick={() => set_error(null)} aria-label="Dismiss error" className="text-red-400/60 hover:text-red-400 transition-colors shrink-0">✕</button>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- **Error toast** — error banner was in the document flow above the Story section, invisible when scrolled down. Converted to a fixed toast (top of screen, always visible) matching the existing copy/save toast pattern
- **Retain work on failure** — operations no longer clear previous results before the request fires; state only clears downstream on success, so a network failure leaves your cleaned text and story intact
- **localStorage recovery** — input, cleaned text, and story auto-save to localStorage; restored on page load so a refresh or accidental navigation doesn't lose your work. Wrapped in try/catch so it degrades gracefully in sandboxed/private-mode environments
- **Specific error messages** — each operation names what failed ("Couldn't build story — try again") instead of a generic "Network error"
- **Accessibility** — `role="alert"` and `aria-label="Dismiss error"` on the error toast

## Test plan

- [ ] Paste text, clean it, generate a story, click **Substack Post** — result should appear and any error should be visible as a top-of-screen toast
- [ ] With network throttled/offline, trigger a failure mid-operation — previous content should remain intact, error toast should appear at top of screen
- [ ] Refresh the page mid-session — input, cleaned text, and story should restore
- [ ] Click **Clear** — all content and localStorage entries should wipe
- [ ] Verify on mobile (scrolled to Story section) that error toasts are visible when an operation fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6hsAhnzBVLGmUF1VtMGko)_