### PR TITLE
Surface specific error cause in Substack Post generation

### DIFF
--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -292,7 +292,13 @@ export default function TextCleanerPage() {
     set_error(null);
 
     try {
-      const resized = await Promise.all(images.map(resize_image));
+      let resized: { data: string; media_type: string }[];
+      try {
+        resized = await Promise.all(images.map(resize_image));
+      } catch {
+        set_error('Failed to process photos — try removing them and retrying');
+        return;
+      }
 
       const res = await fetch('/api/clean-text', {
         method: 'POST',
@@ -304,12 +310,18 @@ export default function TextCleanerPage() {
         }),
       });
 
-      const data = await res.json();
-      if (!res.ok) { set_error(data.error || 'Something went wrong'); return; }
-      set_substack(data.substack);
-      set_substack_usage(data.usage);
+      // res.json() throws if the server returns non-JSON (e.g. a gateway timeout page)
+      let data: { substack?: string; usage?: { input_tokens: number; output_tokens: number }; error?: string } = {};
+      try { data = await res.json(); } catch { /* non-JSON response */ }
+
+      if (!res.ok) {
+        set_error(data.error || `Server error (${res.status}) — try again`);
+        return;
+      }
+      set_substack(data.substack ?? '');
+      set_substack_usage(data.usage ?? null);
     } catch {
-      set_error('Couldn\'t generate Substack post — try again');
+      set_error('Network error — couldn\'t reach the server');
     } finally {
       set_loading_action(null);
     }


### PR DESCRIPTION
## Summary

- Splits the single `generate_substack` catch block into distinct error paths so the toast tells you exactly what went wrong instead of a generic message
- Photo processing failures (canvas/resize errors) → "Failed to process photos — try removing them and retrying"
- Server errors now include the HTTP status code → "Server error (504) — try again"
- Non-JSON responses (e.g. gateway timeout HTML page) handled gracefully — `res.json()` wrapped in its own try/catch so it no longer throws and masks the real status
- Network failures (fetch itself throws) → "Network error — couldn't reach the server"

## Test plan

- [ ] Click Substack Post with no photos — confirm it works or shows a meaningful error
- [ ] Click Substack Post with photos attached — confirm resize + upload works
- [ ] Disable network in DevTools, click Substack Post — confirm "Network error — couldn't reach the server" toast appears and old story content is preserved
- [ ] Confirm error toast is dismissible (✕ button) and visible when scrolled down

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6hsAhnzBVLGmUF1VtMGko)_