### PR TITLE
Harden Substack post generation (timeout, typed errors, retry)

### DIFF
--- a/src/app/api/clean-text/route.ts
+++ b/src/app/api/clean-text/route.ts
@@ -8,7 +8,8 @@ import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODELS } from '@/lib/models';
 
-export const maxDuration = 60;
+// Substack generation with vision can run long; Vercel Pro allows up to 300s.
+export const maxDuration = 300;
 
 async function require_auth(request: NextRequest): Promise<NextResponse | null> {
   const token = await getToken({ req: request });

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -82,6 +82,48 @@ export default function TextCleanerPage() {
     }
   }, []);
 
+  // POST to /api/clean-text with one retry on transient (network/timeout) failure.
+  // Returns { res, data } for any JSON response (ok or not) so callers handle server
+  // errors; throws Error('TIMEOUT') for non-JSON bodies (504 gateway pages) and the
+  // underlying TypeError for dropped connections. Real server errors are not retried.
+  const post_clean_text = async (body: object): Promise<{ res: Response; data: { error?: string; cleaned?: string; story?: string; substack?: string; usage?: { input_tokens: number; output_tokens: number } } }> => {
+    let last_err: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const res = await fetch('/api/clean-text', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        try {
+          const data = await res.json();
+          return { res, data };
+        } catch {
+          // Non-JSON body = gateway timeout (504) or proxy error page, not a server response
+          throw new Error('TIMEOUT');
+        }
+      } catch (e) {
+        last_err = e;
+        if (attempt === 0) {
+          await new Promise(r => setTimeout(r, 800));
+          continue;
+        }
+      }
+    }
+    throw last_err;
+  };
+
+  // Map a thrown request error to an actionable, human message.
+  const describe_request_error = (e: unknown, action: string): string => {
+    const msg = e instanceof Error ? e.message : '';
+    if (msg === 'UNSUPPORTED_IMAGE') return 'One of your photos couldn\'t be read (HEIC isn\'t supported) — remove it or use a JPEG or PNG.';
+    if (msg === 'TIMEOUT') return 'Generation timed out — your work is still here, try again.';
+    if ((typeof navigator !== 'undefined' && navigator.onLine === false) || e instanceof TypeError) {
+      return 'Lost connection — check your signal and try again.';
+    }
+    return `Couldn't ${action} — try again.`;
+  };
+
   const clean = async () => {
     if (!input.trim()) return;
 
@@ -89,27 +131,21 @@ export default function TextCleanerPage() {
     set_error(null);
 
     try {
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: input }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await post_clean_text({ content: input });
 
       if (!res.ok) {
         set_error(data.error || 'Something went wrong');
         return;
       }
 
-      set_cleaned(data.cleaned);
-      set_clean_usage(data.usage);
+      set_cleaned(data.cleaned ?? '');
+      set_clean_usage(data.usage ?? null);
       set_story('');
       set_story_usage(null);
       set_substack('');
       set_substack_usage(null);
-    } catch {
-      set_error('Couldn\'t clean text — try again');
+    } catch (e) {
+      set_error(describe_request_error(e, 'clean text'));
     } finally {
       set_loading_action(null);
     }
@@ -123,25 +159,19 @@ export default function TextCleanerPage() {
     set_error(null);
 
     try {
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: text, mode: 'story' }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await post_clean_text({ content: text, mode: 'story' });
 
       if (!res.ok) {
         set_error(data.error || 'Something went wrong');
         return;
       }
 
-      set_story(data.story);
-      set_story_usage(data.usage);
+      set_story(data.story ?? '');
+      set_story_usage(data.usage ?? null);
       set_substack('');
       set_substack_usage(null);
-    } catch {
-      set_error('Couldn\'t build story — try again');
+    } catch (e) {
+      set_error(describe_request_error(e, 'build story'));
     } finally {
       set_loading_action(null);
     }
@@ -268,7 +298,11 @@ export default function TextCleanerPage() {
         const data_url = canvas.toDataURL('image/jpeg', 0.7);
         resolve({ data: data_url.split(',')[1], media_type: 'image/jpeg' });
       };
-      img.onerror = reject;
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        // Browser can't decode this file (commonly iPhone HEIC); surface a clear message
+        reject(new Error('UNSUPPORTED_IMAGE'));
+      };
       img.src = url;
     });
   };
@@ -294,22 +328,17 @@ export default function TextCleanerPage() {
     try {
       const resized = await Promise.all(images.map(resize_image));
 
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          mode: 'substack',
-          story_text: story.trim(),
-          images: resized,
-        }),
+      const { res, data } = await post_clean_text({
+        mode: 'substack',
+        story_text: story.trim(),
+        images: resized,
       });
 
-      const data = await res.json();
       if (!res.ok) { set_error(data.error || 'Something went wrong'); return; }
-      set_substack(data.substack);
-      set_substack_usage(data.usage);
-    } catch {
-      set_error('Couldn\'t generate Substack post — try again');
+      set_substack(data.substack ?? '');
+      set_substack_usage(data.usage ?? null);
+    } catch (e) {
+      set_error(describe_request_error(e, 'generate Substack post'));
     } finally {
       set_loading_action(null);
     }


### PR DESCRIPTION
## What & why

The "What Am I Trying To Say" tool was surfacing a red toast — *"Couldn't generate Substack post — try again"*. Investigation showed the feature is **not corrupted**: the page, API route, and data are intact, and the toast is the existing error UI working as designed. The real issue is the generation **request** failing — the toast text came from the `catch` branch, which only fires on a timeout, a dropped connection, or a client-side throw before the request is sent (never a normal server error).

## Changes

- **`src/app/api/clean-text/route.ts`** — raise `maxDuration` 60s → 300s. Vision-based Substack generation can approach the old 60s gateway limit, producing a non-JSON 504 that the client read as a generic failure.
- **`src/app/creative/text-cleaner/page.tsx`**
  - Add `post_clean_text` helper: one automatic retry on transient (network/timeout) failures; non-JSON responses are tagged as timeouts. Real server errors return JSON and are **not** retried.
  - Add `describe_request_error`: the toast now distinguishes **timed out** vs **lost connection** vs **unsupported photo (HEIC)** so failures are actionable.
  - `resize_image` now rejects with `UNSUPPORTED_IMAGE` instead of a bare error, so iPhone HEIC photos that fail to decode in-browser produce a clear message rather than a silent generic failure.

No prompt or model changes. Story/cleaned text and attached photos continue to survive every failure path.

## What to test (Vercel preview)

1. Generate a Substack post with no images → succeeds.
2. Generate with 2 JPEG/PNG photos → succeeds and references the images.
3. Add a HEIC photo → clear "couldn't be read (HEIC isn't supported)" message, no request sent.
4. Toggle offline mid-request (devtools) → "Lost connection" message; story + photos remain.

## Notes

Local `npm run build`/`lint` could not run in the agent container (egress policy blocks a dependency tarball, `zod-validation-error@4.0.2`, with a 403). Build verification relies on this preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ig9bZtzYkVYwu8CXt4NCY)_