### PR TITLE
Fix Substack post generation failing in production (+ unblock CI lint)

### DIFF
--- a/src/app/api/clean-text/route.ts
+++ b/src/app/api/clean-text/route.ts
@@ -8,7 +8,8 @@ import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODELS } from '@/lib/models';
 
-export const maxDuration = 60;
+// Substack generation with vision can run long; Vercel Pro allows up to 300s.
+export const maxDuration = 300;
 
 async function require_auth(request: NextRequest): Promise<NextResponse | null> {
   const token = await getToken({ req: request });

--- a/src/app/creative/edit/[id]/editor_client.tsx
+++ b/src/app/creative/edit/[id]/editor_client.tsx
@@ -209,6 +209,7 @@ export default function StoryEditor({
               </div>
               {image_url && !image_failed && (
                 <div className="mb-5 overflow-hidden rounded-2xl border border-white/10">
+                  {/* eslint-disable-next-line @next/next/no-img-element -- arbitrary external story image URL, next/image needs domain allowlist */}
                   <img
                     src={image_url}
                     alt="Story image preview"

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -82,6 +82,48 @@ export default function TextCleanerPage() {
     }
   }, []);
 
+  // POST to /api/clean-text with one retry on transient (network/timeout) failure.
+  // Returns { res, data } for any JSON response (ok or not) so callers handle server
+  // errors; throws Error('TIMEOUT') for non-JSON bodies (504 gateway pages) and the
+  // underlying TypeError for dropped connections. Real server errors are not retried.
+  const post_clean_text = async (body: object): Promise<{ res: Response; data: { error?: string; cleaned?: string; story?: string; substack?: string; usage?: { input_tokens: number; output_tokens: number } } }> => {
+    let last_err: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const res = await fetch('/api/clean-text', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        try {
+          const data = await res.json();
+          return { res, data };
+        } catch {
+          // Non-JSON body = gateway timeout (504) or proxy error page, not a server response
+          throw new Error('TIMEOUT');
+        }
+      } catch (e) {
+        last_err = e;
+        if (attempt === 0) {
+          await new Promise(r => setTimeout(r, 800));
+          continue;
+        }
+      }
+    }
+    throw last_err;
+  };
+
+  // Map a thrown request error to an actionable, human message.
+  const describe_request_error = (e: unknown, action: string): string => {
+    const msg = e instanceof Error ? e.message : '';
+    if (msg === 'UNSUPPORTED_IMAGE') return 'One of your photos couldn\'t be read (HEIC isn\'t supported) — remove it or use a JPEG or PNG.';
+    if (msg === 'TIMEOUT') return 'Generation timed out — your work is still here, try again.';
+    if ((typeof navigator !== 'undefined' && navigator.onLine === false) || e instanceof TypeError) {
+      return 'Lost connection — check your signal and try again.';
+    }
+    return `Couldn't ${action} — try again.`;
+  };
+
   const clean = async () => {
     if (!input.trim()) return;
 
@@ -89,27 +131,21 @@ export default function TextCleanerPage() {
     set_error(null);
 
     try {
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: input }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await post_clean_text({ content: input });
 
       if (!res.ok) {
         set_error(data.error || 'Something went wrong');
         return;
       }
 
-      set_cleaned(data.cleaned);
-      set_clean_usage(data.usage);
+      set_cleaned(data.cleaned ?? '');
+      set_clean_usage(data.usage ?? null);
       set_story('');
       set_story_usage(null);
       set_substack('');
       set_substack_usage(null);
-    } catch {
-      set_error('Couldn\'t clean text — try again');
+    } catch (e) {
+      set_error(describe_request_error(e, 'clean text'));
     } finally {
       set_loading_action(null);
     }
@@ -123,25 +159,19 @@ export default function TextCleanerPage() {
     set_error(null);
 
     try {
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: text, mode: 'story' }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await post_clean_text({ content: text, mode: 'story' });
 
       if (!res.ok) {
         set_error(data.error || 'Something went wrong');
         return;
       }
 
-      set_story(data.story);
-      set_story_usage(data.usage);
+      set_story(data.story ?? '');
+      set_story_usage(data.usage ?? null);
       set_substack('');
       set_substack_usage(null);
-    } catch {
-      set_error('Couldn\'t build story — try again');
+    } catch (e) {
+      set_error(describe_request_error(e, 'build story'));
     } finally {
       set_loading_action(null);
     }
@@ -268,7 +298,11 @@ export default function TextCleanerPage() {
         const data_url = canvas.toDataURL('image/jpeg', 0.7);
         resolve({ data: data_url.split(',')[1], media_type: 'image/jpeg' });
       };
-      img.onerror = reject;
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        // Browser can't decode this file (commonly iPhone HEIC); surface a clear message
+        reject(new Error('UNSUPPORTED_IMAGE'));
+      };
       img.src = url;
     });
   };
@@ -294,22 +328,17 @@ export default function TextCleanerPage() {
     try {
       const resized = await Promise.all(images.map(resize_image));
 
-      const res = await fetch('/api/clean-text', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          mode: 'substack',
-          story_text: story.trim(),
-          images: resized,
-        }),
+      const { res, data } = await post_clean_text({
+        mode: 'substack',
+        story_text: story.trim(),
+        images: resized,
       });
 
-      const data = await res.json();
       if (!res.ok) { set_error(data.error || 'Something went wrong'); return; }
-      set_substack(data.substack);
-      set_substack_usage(data.usage);
-    } catch {
-      set_error('Couldn\'t generate Substack post — try again');
+      set_substack(data.substack ?? '');
+      set_substack_usage(data.usage ?? null);
+    } catch (e) {
+      set_error(describe_request_error(e, 'generate Substack post'));
     } finally {
       set_loading_action(null);
     }


### PR DESCRIPTION
## What & why

The "What Am I Trying To Say" tool surfaced **"Couldn't generate Substack post — try again"** when clicking **Substack Post**. The text-only story/clean paths work; only the vision-based Substack path fails.

**Root cause:** That toast comes from the client `catch` branch, which only fires on a non-JSON response — i.e. a Vercel **504 gateway timeout**, a dropped connection, or a client throw. The Substack call sends images + a long generation and can run past the route's `maxDuration = 60`, producing a 504. The model (`claude-sonnet-4-6`) is fine — the working story output proves it.

**Why this was stuck:** The generation fix was already written in #230, but its `lint` CI check failed on a **pre-existing, unrelated** `@next/next/no-img-element` warning in the story editor, and CI runs `eslint --max-warnings 0`. One warning fails the build, so #230 couldn't merge. This PR includes that fix plus the lint unblock.

## Changes

- **`src/app/api/clean-text/route.ts`** — `maxDuration` 60s → 300s (vision generation can approach the old gateway limit).
- **`src/app/creative/text-cleaner/page.tsx`**
  - `post_clean_text` helper: one automatic retry on transient/timeout failures; non-JSON bodies tagged as timeouts; real server JSON errors are returned, not retried.
  - `describe_request_error`: actionable messages — **timed out** vs **lost connection** vs **unsupported HEIC photo**.
  - `resize_image` rejects undecodable images with `UNSUPPORTED_IMAGE` (iPhone HEIC) instead of a silent generic failure.
  - `clean`, `turn_into_story`, and `generate_substack` route through the helper; story/cleaned text and attached photos survive every failure path.
- **`src/app/creative/edit/[id]/editor_client.tsx`** — add a targeted `eslint-disable-next-line @next/next/no-img-element` for the intentional external-URL `<img>` preview (matches existing convention in `story_image.tsx` and `text-cleaner/page.tsx`). This is what unblocks CI.

No prompt or model changes.

## Verification

- CI `lint` (`eslint --max-warnings 0`) must go green — it was previously failing on the editor `<img>` warning.
- Functional (preview): Substack with no images succeeds; with 2 JPEG/PNG photos succeeds and references them; a HEIC photo gives a clear "HEIC isn't supported" message with no request sent; content/photos survive failures.

## Notes

- Supersedes #230 (same generation fix, plus the lint fix #230 was missing).
- `maxDuration = 300` takes effect on Vercel **Pro**; on Hobby it's capped at 60s. If timeouts persist after deploy, the next lever is lowering the Substack call's `max_tokens` (8000 is far more than the 200–350-word output needs).
- Local `npm ci` is blocked by the egress policy (403 on `zod-validation-error@4.0.2`), so build/lint verification relies on CI, which installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpdDGjwWBs8QyCQzBkx5Ld)_