### PR TITLE
Mobile nav drawer + home page reorder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import NavTabs from '@/components/nav_tabs';
 import { TOOLS } from '@/lib/tools';
+import { SECTION_ACCENTS } from '@/lib/sections';
 
 interface HealthData {
   posts: { total: number };
@@ -25,47 +26,43 @@ interface MiniLink {
 interface Category {
   title: string;
   description: string;
-  icon: string;
   color: string;
   links: MiniLink[];
 }
 
 const ADMIN_QUICK_LINKS = [
-  { group: 'GitHub',    links: [
-    { label: 'Repo',   href: 'https://github.com/boneshakerbike/onthisday' },
-    { label: 'Issues', href: 'https://github.com/boneshakerbike/onthisday/issues' },
-  ]},
-  { group: 'Vercel',    links: [
-    { label: 'Deploys',   href: 'https://vercel.com/boneshakerbikes-projects/~/deployments' },
-    { label: 'Env Vars',  href: 'https://vercel.com/boneshakerbikes-projects/8i11/settings/environment-variables' },
-  ]},
-  { group: 'Anthropic', links: [
-    { label: 'Console', href: 'https://console.anthropic.com' },
-    { label: 'Usage',   href: 'https://claude.ai/settings/usage' },
-  ]},
-  { group: 'Substack',  links: [
-    { label: 'Scheduled', href: 'https://8i11.substack.com/publish/posts/scheduled' },
-  ]},
-  { group: 'Turso',     links: [
-    { label: 'Turso', href: 'https://app.turso.tech' },
-  ]},
-  { group: 'Oura',      links: [
-    { label: 'Oura Dev', href: 'https://developer.ouraring.com/applications' },
-  ]},
+  { label: 'Repo',      href: 'https://github.com/boneshakerbike/onthisday' },
+  { label: 'Issues',    href: 'https://github.com/boneshakerbike/onthisday/issues' },
+  { label: 'Deploys',   href: 'https://vercel.com/boneshakerbikes-projects/~/deployments' },
+  { label: 'Env Vars',  href: 'https://vercel.com/boneshakerbikes-projects/8i11/settings/environment-variables' },
+  { label: 'Console',   href: 'https://console.anthropic.com' },
+  { label: 'Usage',     href: 'https://claude.ai/settings/usage' },
+  { label: 'Scheduled', href: 'https://8i11.substack.com/publish/posts/scheduled' },
+  { label: 'Turso',     href: 'https://app.turso.tech' },
+  { label: 'Oura Dev',  href: 'https://developer.ouraring.com/applications' },
 ];
 
-function AdminSection({ title, children }: { title: string; children: React.ReactNode }) {
-  const [open, set_open] = useState(false);
+function AdminSection({
+  title,
+  children,
+  is_open,
+  on_toggle,
+}: {
+  title: string;
+  children: React.ReactNode;
+  is_open: boolean;
+  on_toggle: () => void;
+}) {
   return (
     <div className="border border-white/10 rounded-lg overflow-hidden">
       <button
-        onClick={() => set_open(o => !o)}
+        onClick={on_toggle}
         className="w-full flex justify-between items-center px-3 py-2 text-sm text-gray-300 hover:bg-white/5 transition-colors text-left"
       >
         <span>{title}</span>
-        <span className="text-gray-400">{open ? '▲' : '▼'}</span>
+        <span className="text-gray-400">{is_open ? '▲' : '▼'}</span>
       </button>
-      {open && (
+      {is_open && (
         <div className="px-3 py-3 text-sm text-gray-400 border-t border-white/10">
           {children}
         </div>
@@ -78,6 +75,7 @@ export default function HomePage() {
   const { data: session } = useSession();
   const is_admin = !!(session?.user && (session.user as { id?: string }).id !== 'guest');
   const [health, set_health] = useState<HealthData | null>(null);
+  const [open_doc, set_open_doc] = useState<string | null>(null);
 
   useEffect(() => { document.title = '8i11 | Home'; }, []);
 
@@ -90,17 +88,8 @@ export default function HomePage() {
 
   const categories: Category[] = [
     {
-      title: 'Tools',
-      description: 'Utilities for writing, thinking, and building',
-      icon: '🛠️',
-      color: 'purple',
-      // Links sourced from src/lib/tools.ts — single source of truth
-      links: TOOLS.map((t) => ({ label: t.label, href: t.path })),
-    },
-    {
       title: 'Creative',
       description: 'Browse Substack posts by date, generate reflective stories',
-      icon: '✍️',
       color: 'cyan',
       links: [
         { label: 'On This Day', href: '/creative' },
@@ -109,9 +98,15 @@ export default function HomePage() {
       ],
     },
     {
+      title: 'Tools',
+      description: 'Utilities for writing, thinking, and building',
+      color: 'purple',
+      // Links sourced from src/lib/tools.ts — single source of truth
+      links: TOOLS.map((t) => ({ label: t.label, href: t.path })),
+    },
+    {
       title: 'Health',
       description: 'Oura Ring, Strava, and COROS training data',
-      icon: '🚴',
       color: 'green',
       links: [
         ...(is_admin ? [{ label: 'Coach', href: '/coach' }] : []),
@@ -123,7 +118,6 @@ export default function HomePage() {
     {
       title: 'Games',
       description: 'Pixel art classics, brick breakers, and F1 predictions',
-      icon: '🎮',
       color: 'pink',
       links: [
         { label: 'Frogger', href: '/games/frogger' },
@@ -134,7 +128,6 @@ export default function HomePage() {
     {
       title: 'Weather',
       description: 'TV-optimized weather display for Missoula, MT',
-      icon: '🌤️',
       color: 'amber',
       links: [
         { label: 'Weather Display', href: '/weather' },
@@ -156,140 +149,155 @@ export default function HomePage() {
         <NavTabs />
 
         <div className="text-center mb-12 mt-4">
-          <h1 className="text-4xl font-light text-cyan-400 mb-2">8i11</h1>
           <p className="text-gray-400 text-sm">Creative tools and games by William Martin</p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-16">
           {categories.map((cat) => {
             const colors = color_map[cat.color];
-            const is_tools = cat.title === 'Tools';
             return (
               <div
                 key={cat.title}
-                className={`p-6 rounded-xl border ${colors.border} bg-white/5 ${is_tools ? 'sm:col-span-2' : ''}`}
+                className={`p-6 rounded-xl border ${colors.border} bg-white/5`}
               >
-                <div className="text-3xl mb-3">{cat.icon}</div>
-                <h2 className={`text-lg font-medium ${colors.text} mb-1`}>{cat.title}</h2>
+                <h2 className="text-lg font-medium mb-1" style={{ color: SECTION_ACCENTS[cat.title] }}>{cat.title}</h2>
                 <p className="text-gray-400 text-sm leading-relaxed mb-3">{cat.description}</p>
 
-                {/* Tool links */}
-                <div className="flex flex-col sm:flex-row flex-wrap gap-1.5 mb-1">
+                {/* Action links */}
+                <div className="flex flex-wrap gap-2 mb-1">
                   {cat.links.map((link) => (
-                    <Link key={link.label} href={link.href}
-                      className="px-2 py-1 text-xs rounded bg-white/5 border border-purple-400/20 text-purple-400/80 hover:text-purple-400 hover:bg-white/10 transition-colors">
+                    <Link
+                      key={link.label}
+                      href={link.href}
+                      className="flex-1 basis-[140px] min-w-[130px] px-3 py-3 rounded-lg text-sm text-left text-[#bca6f7] bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.26)] hover:bg-[rgba(167,139,250,0.16)] hover:border-[rgba(167,139,250,0.5)] transition-colors"
+                    >
                       {link.label}
                     </Link>
                   ))}
                 </div>
-
-                {/* Admin quick links grouped by service */}
-                {is_tools && is_admin && (
-                  <div className="flex flex-wrap gap-1.5 mt-2 items-center">
-                    {ADMIN_QUICK_LINKS.map((group, i) => (
-                      <>
-                        {i > 0 && <span key={`sep-${group.group}`} className="text-gray-700 text-xs">|</span>}
-                        {group.links.map((link) => (
-                          <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer"
-                            className="px-2 py-1 text-xs rounded bg-cyan-400/10 border border-cyan-400/20 text-cyan-400 hover:bg-cyan-400/20 transition-colors">
-                            {link.label} ↗
-                          </a>
-                        ))}
-                      </>
-                    ))}
-                  </div>
-                )}
-
-                {/* Admin collapsible sections */}
-                {is_tools && is_admin && (
-                  <div className="space-y-1.5 mt-4">
-                    <AdminSection title="Permissions &amp; Access Control">
-                      <p className="mb-3">Two-tier model: <strong className="text-white">admin</strong> (GitHub login) and <strong className="text-white">guest</strong> (PIN login). Every GitHub user on the allowlist gets full admin access.</p>
-                      <h4 className="font-medium text-cyan-400 mt-3 mb-2">Identity</h4>
-                      <p className="text-gray-300 mb-2">Session carries <code className="bg-white/10 px-1 rounded">user.id</code>. GitHub users get their numeric ID; guest PIN users get the string <code className="bg-white/10 px-1 rounded">guest</code>. Every check is: <em>is this user &quot;guest&quot; or not?</em></p>
-                      <h4 className="font-medium text-cyan-400 mt-3 mb-2">What each tier can do</h4>
-                      <div className="overflow-x-auto">
-                        <table className="w-full text-sm">
-                          <thead><tr className="text-left border-b border-white/10"><th className="py-2 pr-4 text-gray-400">Action</th><th className="py-2 pr-4 text-gray-400">Admin</th><th className="py-2 text-gray-400">Guest</th></tr></thead>
-                          <tbody className="text-gray-300">
-                            {[['Use all tools & pages','✓','✓'],['F1: make predictions','✓','✓'],['Generate AI stories','✓','✓'],['F1: manage roster & reset','✓','✗']].map(([action, adm, gst]) => (
-                              <tr key={action} className="border-b border-white/5">
-                                <td className="py-1.5 pr-4">{action}</td>
-                                <td className={`py-1.5 pr-4 ${adm === '✓' ? 'text-green-400' : 'text-red-400'}`}>{adm}</td>
-                                <td className={`py-1.5 ${gst === '✓' ? 'text-green-400' : 'text-red-400'}`}>{gst}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                      <h4 className="font-medium text-cyan-400 mt-3 mb-1">Public routes (no login)</h4>
-                      <p className="text-gray-300 text-sm"><code className="bg-white/10 px-1 rounded">/story/*</code> <code className="bg-white/10 px-1 rounded">/archive</code> <code className="bg-white/10 px-1 rounded">/games</code> <code className="bg-white/10 px-1 rounded">/privacy</code> <code className="bg-white/10 px-1 rounded">/terms</code> <code className="bg-white/10 px-1 rounded">/login</code></p>
-                      <div className="mt-3 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded text-sm">
-                        <strong className="text-yellow-400">Note:</strong> No granular roles yet — all GitHub allowlist users are equivalent admins.
-                      </div>
-                    </AdminSection>
-                    <AdminSection title="Managing Guest PINs">
-                      <p className="mb-3">PINs let friends access the app without a GitHub account. Stored in Vercel env vars.</p>
-                      <h4 className="font-medium text-cyan-400 mt-3 mb-2">Add or change PINs</h4>
-                      <ol className="list-decimal list-inside space-y-1.5 text-gray-300 text-sm">
-                        <li>Vercel Dashboard → <strong>onthisday</strong> → Settings → Environment Variables</li>
-                        <li>Find or create <code className="bg-white/10 px-1 rounded">GUEST_PINS</code></li>
-                        <li>Set value: <code className="bg-white/10 px-1 rounded">mom1234,friend5678</code></li>
-                        <li>Save → Deployments → ... → Redeploy</li>
-                      </ol>
-                      <p className="text-gray-300 text-sm mt-3">To revoke: remove their PIN and redeploy.</p>
-                      <div className="mt-3 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded text-sm">
-                        <strong className="text-yellow-400">Note:</strong> Legacy <code className="bg-white/10 px-1 rounded">GUEST_PIN</code> still works alongside <code className="bg-white/10 px-1 rounded">GUEST_PINS</code>.
-                      </div>
-                    </AdminSection>
-                    <AdminSection title="Managing GitHub Users">
-                      <p className="mb-3">Default: only <code className="bg-white/10 px-1 rounded">boneshakerbike</code> can log in with GitHub.</p>
-                      <h4 className="font-medium text-cyan-400 mt-3 mb-2">Allow other GitHub users</h4>
-                      <ol className="list-decimal list-inside space-y-1.5 text-gray-300 text-sm">
-                        <li>Vercel → Settings → Environment Variables</li>
-                        <li>Create <code className="bg-white/10 px-1 rounded">ALLOWED_GITHUB_USERS</code></li>
-                        <li>Value: comma-separated usernames — <code className="bg-white/10 px-1 rounded">boneshakerbike,frienduser</code></li>
-                        <li>Save and redeploy</li>
-                      </ol>
-                    </AdminSection>
-                    <AdminSection title="Environment Variables Reference">
-                      <div className="overflow-x-auto">
-                        <table className="w-full text-sm">
-                          <thead><tr className="text-left border-b border-white/10"><th className="py-2 pr-4 text-gray-400">Variable</th><th className="py-2 text-gray-400">Purpose</th></tr></thead>
-                          <tbody className="text-gray-300">
-                            {[
-                              ['','Auth',''],
-                              ['GUEST_PINS','Comma-separated guest PINs (agent + human access)',''],
-                              ['GUEST_PIN','Legacy single PIN (still works)',''],
-                              ['ALLOWED_GITHUB_USERS','Comma-separated GitHub login names allowed to authenticate',''],
-                              ['GITHUB_CLIENT_ID','GitHub OAuth app ID',''],
-                              ['GITHUB_CLIENT_SECRET','GitHub OAuth app secret',''],
-                              ['NEXTAUTH_SECRET','Session encryption key',''],
-                              ['','Database',''],
-                              ['TURSO_DATABASE_URL','Production Turso (libSQL) database URL',''],
-                              ['TURSO_AUTH_TOKEN','Production Turso auth token',''],
-                              ['','AI & Integrations',''],
-                              ['ANTHROPIC_API_KEY','Claude API key (stories, prompt review)',''],
-                              ['OURA_CLIENT_ID','Oura Ring OAuth app ID',''],
-                              ['OURA_CLIENT_SECRET','Oura Ring OAuth app secret',''],
-                            ].map((row, i) => row[0] === '' ? (
-                              <tr key={i}><td colSpan={2} className="py-2 pr-4 font-medium text-gray-400 pt-3">{row[1]}</td></tr>
-                            ) : (
-                              <tr key={i} className="border-b border-white/5">
-                                <td className="py-1.5 pr-4"><code className="text-cyan-400">{row[0]}</code></td>
-                                <td className="py-1.5">{row[1]}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    </AdminSection>
-                  </div>
-                )}
               </div>
             );
           })}
         </div>
+
+        {/* Admin & Resources */}
+        {is_admin && (
+          <div className="mb-10">
+            <p className="text-xs uppercase tracking-widest text-gray-400 mb-4">Admin &amp; Resources</p>
+            <div className="flex flex-wrap gap-2 mb-4">
+              {ADMIN_QUICK_LINKS.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-2 py-1 text-xs rounded bg-cyan-400/10 border border-cyan-400/20 text-cyan-400 hover:bg-cyan-400/20 transition-colors"
+                >
+                  {link.label} ↗
+                </a>
+              ))}
+            </div>
+            <div className="space-y-1.5">
+              <AdminSection
+                title="Permissions &amp; Access Control"
+                is_open={open_doc === 'Permissions & Access Control'}
+                on_toggle={() => set_open_doc(open_doc === 'Permissions & Access Control' ? null : 'Permissions & Access Control')}
+              >
+                <p className="mb-3">Two-tier model: <strong className="text-white">admin</strong> (GitHub login) and <strong className="text-white">guest</strong> (PIN login). Every GitHub user on the allowlist gets full admin access.</p>
+                <h4 className="font-medium text-cyan-400 mt-3 mb-2">Identity</h4>
+                <p className="text-gray-300 mb-2">Session carries <code className="bg-white/10 px-1 rounded">user.id</code>. GitHub users get their numeric ID; guest PIN users get the string <code className="bg-white/10 px-1 rounded">guest</code>. Every check is: <em>is this user &quot;guest&quot; or not?</em></p>
+                <h4 className="font-medium text-cyan-400 mt-3 mb-2">What each tier can do</h4>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead><tr className="text-left border-b border-white/10"><th className="py-2 pr-4 text-gray-400">Action</th><th className="py-2 pr-4 text-gray-400">Admin</th><th className="py-2 text-gray-400">Guest</th></tr></thead>
+                    <tbody className="text-gray-300">
+                      {[['Use all tools & pages','✓','✓'],['F1: make predictions','✓','✓'],['Generate AI stories','✓','✓'],['F1: manage roster & reset','✓','✗']].map(([action, adm, gst]) => (
+                        <tr key={action} className="border-b border-white/5">
+                          <td className="py-1.5 pr-4">{action}</td>
+                          <td className={`py-1.5 pr-4 ${adm === '✓' ? 'text-green-400' : 'text-red-400'}`}>{adm}</td>
+                          <td className={`py-1.5 ${gst === '✓' ? 'text-green-400' : 'text-red-400'}`}>{gst}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <h4 className="font-medium text-cyan-400 mt-3 mb-1">Public routes (no login)</h4>
+                <p className="text-gray-300 text-sm"><code className="bg-white/10 px-1 rounded">/story/*</code> <code className="bg-white/10 px-1 rounded">/archive</code> <code className="bg-white/10 px-1 rounded">/games</code> <code className="bg-white/10 px-1 rounded">/privacy</code> <code className="bg-white/10 px-1 rounded">/terms</code> <code className="bg-white/10 px-1 rounded">/login</code></p>
+                <div className="mt-3 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded text-sm">
+                  <strong className="text-yellow-400">Note:</strong> No granular roles yet — all GitHub allowlist users are equivalent admins.
+                </div>
+              </AdminSection>
+              <AdminSection
+                title="Managing Guest PINs"
+                is_open={open_doc === 'Managing Guest PINs'}
+                on_toggle={() => set_open_doc(open_doc === 'Managing Guest PINs' ? null : 'Managing Guest PINs')}
+              >
+                <p className="mb-3">PINs let friends access the app without a GitHub account. Stored in Vercel env vars.</p>
+                <h4 className="font-medium text-cyan-400 mt-3 mb-2">Add or change PINs</h4>
+                <ol className="list-decimal list-inside space-y-1.5 text-gray-300 text-sm">
+                  <li>Vercel Dashboard → <strong>onthisday</strong> → Settings → Environment Variables</li>
+                  <li>Find or create <code className="bg-white/10 px-1 rounded">GUEST_PINS</code></li>
+                  <li>Set value: <code className="bg-white/10 px-1 rounded">mom1234,friend5678</code></li>
+                  <li>Save → Deployments → ... → Redeploy</li>
+                </ol>
+                <p className="text-gray-300 text-sm mt-3">To revoke: remove their PIN and redeploy.</p>
+                <div className="mt-3 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded text-sm">
+                  <strong className="text-yellow-400">Note:</strong> Legacy <code className="bg-white/10 px-1 rounded">GUEST_PIN</code> still works alongside <code className="bg-white/10 px-1 rounded">GUEST_PINS</code>.
+                </div>
+              </AdminSection>
+              <AdminSection
+                title="Managing GitHub Users"
+                is_open={open_doc === 'Managing GitHub Users'}
+                on_toggle={() => set_open_doc(open_doc === 'Managing GitHub Users' ? null : 'Managing GitHub Users')}
+              >
+                <p className="mb-3">Default: only <code className="bg-white/10 px-1 rounded">boneshakerbike</code> can log in with GitHub.</p>
+                <h4 className="font-medium text-cyan-400 mt-3 mb-2">Allow other GitHub users</h4>
+                <ol className="list-decimal list-inside space-y-1.5 text-gray-300 text-sm">
+                  <li>Vercel → Settings → Environment Variables</li>
+                  <li>Create <code className="bg-white/10 px-1 rounded">ALLOWED_GITHUB_USERS</code></li>
+                  <li>Value: comma-separated usernames — <code className="bg-white/10 px-1 rounded">boneshakerbike,frienduser</code></li>
+                  <li>Save and redeploy</li>
+                </ol>
+              </AdminSection>
+              <AdminSection
+                title="Environment Variables Reference"
+                is_open={open_doc === 'Environment Variables Reference'}
+                on_toggle={() => set_open_doc(open_doc === 'Environment Variables Reference' ? null : 'Environment Variables Reference')}
+              >
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead><tr className="text-left border-b border-white/10"><th className="py-2 pr-4 text-gray-400">Variable</th><th className="py-2 text-gray-400">Purpose</th></tr></thead>
+                    <tbody className="text-gray-300">
+                      {[
+                        ['','Auth',''],
+                        ['GUEST_PINS','Comma-separated guest PINs (agent + human access)',''],
+                        ['GUEST_PIN','Legacy single PIN (still works)',''],
+                        ['ALLOWED_GITHUB_USERS','Comma-separated GitHub login names allowed to authenticate',''],
+                        ['GITHUB_CLIENT_ID','GitHub OAuth app ID',''],
+                        ['GITHUB_CLIENT_SECRET','GitHub OAuth app secret',''],
+                        ['NEXTAUTH_SECRET','Session encryption key',''],
+                        ['','Database',''],
+                        ['TURSO_DATABASE_URL','Production Turso (libSQL) database URL',''],
+                        ['TURSO_AUTH_TOKEN','Production Turso auth token',''],
+                        ['','AI & Integrations',''],
+                        ['ANTHROPIC_API_KEY','Claude API key (stories, prompt review)',''],
+                        ['OURA_CLIENT_ID','Oura Ring OAuth app ID',''],
+                        ['OURA_CLIENT_SECRET','Oura Ring OAuth app secret',''],
+                      ].map((row, i) => row[0] === '' ? (
+                        <tr key={i}><td colSpan={2} className="py-2 pr-4 font-medium text-gray-400 pt-3">{row[1]}</td></tr>
+                      ) : (
+                        <tr key={i} className="border-b border-white/5">
+                          <td className="py-1.5 pr-4"><code className="text-cyan-400">{row[0]}</code></td>
+                          <td className="py-1.5">{row[1]}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </AdminSection>
+            </div>
+          </div>
+        )}
 
         {/* Services */}
         <div className="mb-10">

--- a/src/components/nav_tabs.tsx
+++ b/src/components/nav_tabs.tsx
@@ -1,8 +1,9 @@
 /**
  * NavTabs - Main navigation header
- * Tabs: Home | Creative | Tools | Health | Games
- * Tools dropdown sourced from src/lib/tools.ts
- * Dropdowns use Radix UI for collision-safe positioning and accessibility.
+ * Desktop (md+): Radix UI horizontal dropdown bar — Home | Creative | Tools | Health | Games | Weather.
+ * Mobile (< md): hamburger -> single-open accordion drawer (same link sets).
+ * Wordmark "8i11" shown in the header at all breakpoints.
+ * Tools dropdown/group sourced from src/lib/tools.ts; section accents from src/lib/sections.ts.
  */
 
 'use client';
@@ -13,65 +14,82 @@ import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { TOOLS } from '@/lib/tools';
+import { SECTION_ACCENTS } from '@/lib/sections';
 
 interface NavTabsProps {
   theme?: 'dark' | 'light';
 }
 
+interface NavItem {
+  label: string;
+  href: string;
+}
+
 export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
   const pathname = usePathname();
   const { data: session } = useSession();
-  const nav_ref = useRef<HTMLElement>(null);
-  const has_peeked = useRef(false);
-  const [can_scroll_left, set_can_scroll_left] = useState(false);
-  const [can_scroll_right, set_can_scroll_right] = useState(false);
+  const mobile_ref = useRef<HTMLDivElement>(null);
+  const hamburger_ref = useRef<HTMLButtonElement>(null);
   const [is_local, set_is_local] = useState(false);
+  const [menu_open, set_menu_open] = useState(false);
+  const [open_nav, set_open_nav] = useState<string | null>(null);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR-safe: window only accessible client-side
   useEffect(() => { set_is_local(window.location.hostname === 'localhost'); }, []);
 
   const is_light = theme === 'light';
+  const is_guest = (session?.user as { id?: string })?.id === 'guest';
+  const show_coach = !!session && !is_guest;
 
-  // Track nav scroll position for fade indicators
+  // Escape to close (return focus to hamburger) + click outside to close
   useEffect(() => {
-    const nav = nav_ref.current;
-    if (!nav) return;
-    const check_scroll = () => {
-      set_can_scroll_left(nav.scrollLeft > 0);
-      set_can_scroll_right(nav.scrollLeft + nav.clientWidth < nav.scrollWidth - 1);
+    if (!menu_open) return;
+    const on_key = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { set_menu_open(false); hamburger_ref.current?.focus(); }
     };
-    check_scroll();
-    nav.addEventListener('scroll', check_scroll);
-    const observer = new ResizeObserver(check_scroll);
-    observer.observe(nav);
+    const on_pointer = (e: PointerEvent) => {
+      if (mobile_ref.current && !mobile_ref.current.contains(e.target as Node)) set_menu_open(false);
+    };
+    document.addEventListener('keydown', on_key);
+    document.addEventListener('pointerdown', on_pointer);
     return () => {
-      nav.removeEventListener('scroll', check_scroll);
-      observer.disconnect();
+      document.removeEventListener('keydown', on_key);
+      document.removeEventListener('pointerdown', on_pointer);
     };
-  }, []);
-
-  // Scroll-peek animation on mount
-  useEffect(() => {
-    const nav = nav_ref.current;
-    if (!nav || has_peeked.current) return;
-    let t2: ReturnType<typeof setTimeout>;
-    const t1 = setTimeout(() => {
-      if (nav.scrollWidth <= nav.clientWidth) return;
-      has_peeked.current = true;
-      nav.scrollTo({ left: 48 });
-      t2 = setTimeout(() => {
-        nav.scrollTo({ left: 0, behavior: 'smooth' });
-      }, 600);
-    }, 300);
-    return () => { clearTimeout(t1); clearTimeout(t2); };
-  }, []);
-
+  }, [menu_open]);
 
   const is_active = (path: string) => {
     if (path === '/') return pathname === '/';
     return pathname.startsWith(path);
   };
 
+  // --- Shared link sets (Tools is data-driven; Coach is auth-gated) ---
+  const creative_items: NavItem[] = [
+    { label: 'On This Day', href: '/creative' },
+    { label: 'Archive', href: '/creative/archive' },
+    { label: 'What Am I Trying To Say', href: '/creative/text-cleaner' },
+  ];
+  const tools_items: NavItem[] = TOOLS.map((t) => ({ label: t.label, href: t.path }));
+  const health_items: NavItem[] = [
+    ...(show_coach ? [{ label: 'Coach', href: '/coach' }] : []),
+    { label: 'Oura', href: '/health/oura' },
+    { label: 'Strava', href: '/health/strava' },
+    { label: 'COROS', href: '/health/coros' },
+  ];
+  const games_items: NavItem[] = [
+    { label: 'Frogger', href: '/games/frogger' },
+    { label: 'Breakout', href: '/games/breakout' },
+    { label: 'F1 Predictions', href: '/games/f1' },
+  ];
+
+  const nav_groups: { label: string; base: string; items: NavItem[] }[] = [
+    { label: 'Creative', base: '/creative', items: creative_items },
+    { label: 'Tools', base: '/tools', items: tools_items },
+    { label: 'Health', base: '/health', items: health_items },
+    { label: 'Games', base: '/games', items: games_items },
+  ];
+
+  // ---------- Desktop (md+) styles ----------
   const tab_class = (path: string) => {
     const base = 'px-4 sm:px-3 py-3 sm:py-2 text-base sm:text-sm min-h-[44px] sm:min-h-0 font-medium transition-all border-b-2 whitespace-nowrap';
     if (is_active(path)) {
@@ -99,159 +117,74 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
   const trigger_class = (path: string) =>
     `group bg-transparent outline-none focus:outline-none focus-visible:outline-none ${tab_class(path)} flex items-center gap-1`;
 
+  const desktop_dropdown = (label: string, base: string, items: NavItem[], extra_content_class = '') => (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className={trigger_class(base)}>
+          {label} {chevron_svg}
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={`${content_class} ${extra_content_class}`} sideOffset={4} align="start" avoidCollisions>
+          {items.map((it) => (
+            <DropdownMenu.Item key={it.href} asChild>
+              <Link href={it.href} className={item_class}>{it.label}</Link>
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+
+  // ---------- Mobile (< md) drawer styles ----------
+  const wordmark_color = is_light ? 'text-[#c4704b]' : 'text-cyan-400';
+  // Per-section accent: dark = section hue; light = single terracotta.
+  const group_accent = (label: string) => (is_light ? '#c4704b' : SECTION_ACCENTS[label]);
+
+  const drawer_link_class = (path: string) => {
+    const base = 'flex items-center w-full text-left px-4 py-3 rounded-lg text-base font-semibold min-h-[44px] transition-colors';
+    if (is_active(path)) return `${base} ${is_light ? 'text-[#c4704b]' : 'text-cyan-400'}`;
+    return `${base} ${is_light ? 'text-gray-700 hover:text-[#c4704b]' : 'text-gray-200 hover:text-white'}`;
+  };
+
   return (
-    <header className={`mb-6 border-b ${is_light ? 'border-[#e5e0d8]' : 'border-white/10'}`}>
-      <div className="flex items-center justify-between">
-        {/* Left: Navigation tabs - scrollable on mobile */}
-        <div className="relative flex-1 min-w-0">
-          {can_scroll_left && (
-            <button
-              onClick={() => nav_ref.current?.scrollBy({ left: -120, behavior: 'smooth' })}
-              className={`absolute left-0 top-0 bottom-0 w-8 z-20 flex items-center justify-center font-bold text-lg ${is_light ? 'text-[#c4704b]' : 'text-cyan-400'}`}
-              aria-label="Scroll navigation left"
-            >
-              ‹
-            </button>
-          )}
-          {can_scroll_left && (
-            <div className={`absolute left-8 top-0 bottom-0 w-8 z-10 pointer-events-none bg-gradient-to-r ${is_light ? 'from-[#faf8f5]' : 'from-[#1a1a2e]'} to-transparent`} />
-          )}
-          {can_scroll_right && (
-            <div className={`absolute right-8 top-0 bottom-0 w-8 z-10 pointer-events-none bg-gradient-to-l ${is_light ? 'from-[#faf8f5]' : 'from-[#1a1a2e]'} to-transparent`} />
-          )}
-          {can_scroll_right && (
-            <button
-              onClick={() => nav_ref.current?.scrollBy({ left: 120, behavior: 'smooth' })}
-              className={`absolute right-0 top-0 bottom-0 w-8 z-20 flex items-center justify-center font-bold text-lg animate-pulse ${is_light ? 'text-[#c4704b]' : 'text-cyan-400'}`}
-              aria-label="Scroll navigation right"
-            >
-              ›
-            </button>
-          )}
-          <nav ref={nav_ref} className="flex items-center overflow-x-auto scrollbar-hide pr-8">
-            {/* Home */}
-            <Link href="/" className={tab_class('/')}>
-              Home
-            </Link>
+    <header className={`relative mb-6 border-b ${is_light ? 'border-[#e5e0d8]' : 'border-white/10'}`}>
+      <div className="flex items-center justify-between gap-3">
+        {/* Left cluster: hamburger (mobile) + wordmark + desktop nav */}
+        <div ref={mobile_ref} className="flex items-center min-w-0 flex-1 gap-2">
+          {/* Hamburger — mobile only */}
+          <button
+            ref={hamburger_ref}
+            type="button"
+            onClick={() => set_menu_open((o) => !o)}
+            aria-label={menu_open ? 'Close menu' : 'Open menu'}
+            aria-expanded={menu_open}
+            aria-controls="mobile-nav-drawer"
+            className={`md:hidden flex flex-col items-center justify-center gap-[4px] w-10 h-10 rounded-lg border ${is_light ? 'border-[#e5e0d8] bg-black/[0.02]' : 'border-white/15 bg-white/[0.04]'}`}
+          >
+            <span className={`w-[18px] h-[2px] rounded-full ${is_light ? 'bg-gray-600' : 'bg-gray-200'}`} />
+            <span className={`w-[18px] h-[2px] rounded-full ${is_light ? 'bg-gray-600' : 'bg-gray-200'}`} />
+            <span className={`w-[18px] h-[2px] rounded-full ${is_light ? 'bg-gray-600' : 'bg-gray-200'}`} />
+          </button>
 
-            {/* Creative dropdown */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button className={trigger_class('/creative')}>
-                  Creative {chevron_svg}
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className={content_class}
-                  sideOffset={4}
-                  align="start"
-                  avoidCollisions
-                >
-                  <DropdownMenu.Item asChild>
-                    <Link href="/creative" className={item_class}>On This Day</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/creative/archive" className={item_class}>Archive</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/creative/text-cleaner" className={item_class}>What Am I Trying To Say</Link>
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
+          {/* Wordmark — all breakpoints */}
+          <Link href="/" className={`text-xl font-extrabold tracking-tight ${wordmark_color} mr-1`}>
+            8i11
+          </Link>
 
-            {/* Tools dropdown */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button className={trigger_class('/tools')}>
-                  Tools {chevron_svg}
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className={content_class}
-                  sideOffset={4}
-                  align="start"
-                  avoidCollisions
-                >
-                  {TOOLS.map((tool) => (
-                    <DropdownMenu.Item key={tool.path} asChild>
-                      <Link href={tool.path} className={item_class}>{tool.label}</Link>
-                    </DropdownMenu.Item>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-
-            {/* Health dropdown */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button className={trigger_class('/health')}>
-                  Health {chevron_svg}
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className={content_class}
-                  sideOffset={4}
-                  align="start"
-                  avoidCollisions
-                >
-                  {session && (session.user as { id?: string })?.id !== 'guest' && (
-                    <DropdownMenu.Item asChild>
-                      <Link href="/coach" className={item_class}>Coach</Link>
-                    </DropdownMenu.Item>
-                  )}
-                  <DropdownMenu.Item asChild>
-                    <Link href="/health/oura" className={item_class}>Oura</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/health/strava" className={item_class}>Strava</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/health/coros" className={item_class}>COROS</Link>
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-
-            {/* Games dropdown */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button className={trigger_class('/games')}>
-                  Games {chevron_svg}
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className={`${content_class} min-w-[150px]`}
-                  sideOffset={4}
-                  align="start"
-                  avoidCollisions
-                >
-                  <DropdownMenu.Item asChild>
-                    <Link href="/games/frogger" className={item_class}>Frogger</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/games/breakout" className={item_class}>Breakout</Link>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item asChild>
-                    <Link href="/games/f1" className={item_class}>F1 Predictions</Link>
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-
-            {/* Weather (standalone link) */}
-            <Link href="/weather" className={tab_class('/weather')}>
-              Weather
-            </Link>
+          {/* Desktop nav — md+ only */}
+          <nav className="hidden md:flex items-center overflow-x-auto scrollbar-hide">
+            <Link href="/" className={tab_class('/')}>Home</Link>
+            {desktop_dropdown('Creative', '/creative', creative_items)}
+            {desktop_dropdown('Tools', '/tools', tools_items)}
+            {desktop_dropdown('Health', '/health', health_items)}
+            {desktop_dropdown('Games', '/games', games_items, 'min-w-[150px]')}
+            <Link href="/weather" className={tab_class('/weather')}>Weather</Link>
           </nav>
         </div>
 
-        {/* Right: User info */}
-        <div className="flex items-center whitespace-nowrap ml-4">
+        {/* Right: user cluster — desktop only (mobile shows it in the drawer) */}
+        <div className="hidden md:flex items-center whitespace-nowrap ml-4">
           {is_local && (
             <a
               href="http://localhost:8080"
@@ -273,6 +206,75 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
           )}
         </div>
       </div>
+
+      {/* Mobile drawer — < md only */}
+      {menu_open && (
+        <div
+          id="mobile-nav-drawer"
+          className={`md:hidden absolute top-full left-0 right-0 z-[9999] mt-px max-h-[70vh] overflow-y-auto p-2 rounded-b-xl shadow-[0_16px_40px_rgba(0,0,0,0.5)] border-b ${is_light ? 'bg-white/95 backdrop-blur-md border-[#e5e0d8]' : 'bg-[#0d1326]/98 backdrop-blur-md border-white/10'}`}
+        >
+          {/* Home (direct link) */}
+          <Link href="/" onClick={() => set_menu_open(false)} className={drawer_link_class('/')}>Home</Link>
+
+          {/* Groups */}
+          {nav_groups.map((g) => {
+            const open = open_nav === g.label;
+            const active = is_active(g.base);
+            return (
+              <div key={g.label}>
+                <button
+                  type="button"
+                  onClick={() => set_open_nav((cur) => (cur === g.label ? null : g.label))}
+                  aria-expanded={open}
+                  className="flex items-center w-full text-left px-4 py-3 rounded-lg text-base font-semibold min-h-[44px]"
+                  style={{ color: active || open ? group_accent(g.label) : undefined }}
+                >
+                  <span className="flex-1" style={{ color: group_accent(g.label) }}>{g.label}</span>
+                  <span className={`text-xs transition-transform ${is_light ? 'text-gray-400' : 'text-gray-500'} ${open ? 'rotate-90' : ''}`}>▸</span>
+                </button>
+                {open && (
+                  <div className="pb-2">
+                    {g.items.map((it) => (
+                      <Link
+                        key={it.href}
+                        href={it.href}
+                        onClick={() => set_menu_open(false)}
+                        className={`block w-full text-left pl-7 pr-4 py-2.5 text-[15px] min-h-[44px] transition-colors ${is_active(it.href) ? (is_light ? 'text-[#c4704b]' : 'text-cyan-400') : (is_light ? 'text-gray-600 hover:text-[#c4704b]' : 'text-gray-300 hover:text-white')}`}
+                      >
+                        {it.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Weather (direct link) */}
+          <Link href="/weather" onClick={() => set_menu_open(false)} className={drawer_link_class('/weather')}>Weather</Link>
+
+          {/* Account cluster */}
+          <div className={`mt-2 mx-2 border-t ${is_light ? 'border-[#e5e0d8]' : 'border-white/10'}`} />
+          <div className="flex items-center justify-between px-4 py-3">
+            <div className={`text-xs ${is_light ? 'text-gray-500' : 'text-gray-400'}`}>
+              {is_local && (
+                <a href="http://localhost:8080" className={`mr-3 ${is_light ? 'hover:text-[#c4704b]' : 'hover:text-cyan-400'}`}>Dev Hub</a>
+              )}
+              {session && (
+                <span>{session.user?.name || session.user?.email || 'Guest'}</span>
+              )}
+            </div>
+            {session && (
+              <button
+                onClick={() => signOut()}
+                className={`px-3 py-1.5 rounded-lg text-xs font-semibold border ${is_light ? 'border-red-400/40 text-red-500' : 'border-red-400/40 text-red-400'}`}
+              >
+                Sign out
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/nav_tabs.tsx
+++ b/src/components/nav_tabs.tsx
@@ -28,7 +28,7 @@ interface NavItem {
 export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
   const pathname = usePathname();
   const { data: session } = useSession();
-  const mobile_ref = useRef<HTMLDivElement>(null);
+  const mobile_ref = useRef<HTMLElement>(null);
   const hamburger_ref = useRef<HTMLButtonElement>(null);
   const [is_local, set_is_local] = useState(false);
   const [menu_open, set_menu_open] = useState(false);
@@ -148,10 +148,10 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
   };
 
   return (
-    <header className={`relative mb-6 border-b ${is_light ? 'border-[#e5e0d8]' : 'border-white/10'}`}>
+    <header ref={mobile_ref} className={`relative mb-6 border-b ${is_light ? 'border-[#e5e0d8]' : 'border-white/10'}`}>
       <div className="flex items-center justify-between gap-3">
         {/* Left cluster: hamburger (mobile) + wordmark + desktop nav */}
-        <div ref={mobile_ref} className="flex items-center min-w-0 flex-1 gap-2">
+        <div className="flex items-center min-w-0 flex-1 gap-2">
           {/* Hamburger — mobile only */}
           <button
             ref={hamburger_ref}

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared per-section accent colors (exact hex) — single source of truth for the
+ * accents used by the mobile nav drawer (src/components/nav_tabs.tsx) and the
+ * home-page section cards (src/app/page.tsx). Keeps the two surfaces from drifting
+ * (previously page.tsx used Tailwind purple-400/green-400 which don't match the
+ * design hexes #a78bfa / #34d399).
+ *
+ * Dark theme only. Light theme uses the single terracotta accent (#c4704b);
+ * per-section color is a dark-theme-only feature.
+ */
+export const SECTION_ACCENTS: Record<string, string> = {
+  Creative: '#22d3ee',
+  Tools: '#a78bfa',
+  Health: '#34d399',
+  Games: '#f472b6',
+  Weather: '#fbbf24',
+};
+
+/** Wordmark / brand accent (dark theme). Light theme uses terracotta #c4704b. */
+export const BRAND_ACCENT = '#22d3ee';


### PR DESCRIPTION
Mobile-only (`< md`) reshape of the app shell, per the designer handoff. Desktop (`md+`) keeps the existing Radix dropdown bar.

## What changed
**Nav (`src/components/nav_tabs.tsx`)**
- `< md`: hamburger → single-open accordion drawer (Home/Weather are direct links; Creative/Tools/Health/Games expand). Account cluster (name, Sign out, Dev Hub on localhost) pinned in the drawer footer.
- `8i11` wordmark moved into the header at **all breakpoints** (hero wordmark dropped from home).
- Deleted the mobile horizontal-scroll machinery (edge arrows, gradient fades, on-mount peek).
- Coach gating + `tools.ts` sourcing preserved. Light theme uses the single terracotta accent.
- a11y: hamburger `aria-expanded`/`aria-controls`, group buttons `aria-expanded`, Escape + click-outside to close, drawer closes on link tap.

**Home (`src/app/page.tsx`)**
- Section cards reordered Creative → Tools → Health → Games → Weather.
- Action buttons laid 2-up; per-section emoji stripped; hero wordmark removed.
- **Admin & Resources** extracted out of the Tools card into its own section above **Services**; admin chips flattened to a single 9-chip row; doc accordions are now single-open.

**Shared (`src/lib/sections.ts`)** — new `SECTION_ACCENTS` map so nav + home titles use the same exact hex (fixes prior `purple-400`/`green-400` drift).

## Scope decisions (flagged, not silently done)
- Kept the header **non-sticky**. The mock's descriptive section shows a sticky/blurred header, but it's not in the handoff's authoritative "To change" list and would alter scroll behavior on ~21 pages. Easy follow-up if wanted.
- No wholesale card restyle — stuck to the "To change" checklist; desktop is essentially unchanged.

## How it was built
Planned, then a separate **Opus** agent reviewed the plan (caught the admin-block-is-nested-not-a-move issue, the grouped-vs-flat chips, the vanishing wordmark, and the no-light-palette gap). Mechanical `page.tsx` edits delegated to a **Sonnet** agent; drawer logic + light theme done on the Opus path.

## Test (mobile viewport / `< md`)
- Tap ☰ → drawer drops in; tap a group → expands, opening another collapses the first.
- Home/Weather navigate + close the drawer; Escape and tap-outside close it.
- Coach appears under Health only when signed in as a non-guest.
- Wordmark shows in the header on every page; home hero shows tagline only.
- Resize to `md+`: original Radix dropdown bar, no arrows/fades/peek.
- Home: card order, 2-up buttons, Admin above Services, single-open doc accordions.
- Light theme (`/story/[id]`, `/creative/archive`): drawer uses terracotta accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)