### PR TITLE
Tighten mobile landing page; rename "What Am I Trying To Say" → "Say What?"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ src/
       page.tsx                    # On This Day: browse posts, generate stories
       archive/page.tsx            # Story archive (public)
       edit/[id]/page.tsx          # Story editor
-      text-cleaner/               # What Am I Trying To Say: text cleaning + story builder
+      text-cleaner/               # Say What?: text cleaning + story builder
     story/[id]/page.tsx           # Shareable story page (public)
     tools/
       markdown/                   # Rich text → Markdown converter

--- a/src/app/api/text-notes/route.ts
+++ b/src/app/api/text-notes/route.ts
@@ -1,6 +1,6 @@
 /**
  * API route: /api/text-notes
- * CRUD for saved "What Am I Trying To Say" notes
+ * CRUD for saved "Say What?" notes
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -1,5 +1,5 @@
 /**
- * What Am I Trying To Say
+ * Say What?
  * Paste rough text, get it cleaned up for clarity, edit, then copy
  */
 
@@ -359,7 +359,7 @@ export default function TextCleanerPage() {
         <NavTabs />
 
         <h1 className="text-center text-3xl font-light text-cyan-400 mb-2">
-          What Am I Trying To Say
+          Say What?
         </h1>
         <p className="text-center text-gray-400 mb-8">
           Clean up your ramble, then turn it into a story

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,7 @@ export default function HomePage() {
       links: [
         { label: 'On This Day', href: '/creative' },
         { label: 'Archive', href: '/creative/archive' },
-        { label: 'What Am I Trying To Say', href: '/creative/text-cleaner' },
+        { label: 'Say What?', href: '/creative/text-cleaner' },
       ],
     },
     {
@@ -148,7 +148,7 @@ export default function HomePage() {
       <div className="max-w-3xl mx-auto">
         <NavTabs />
 
-        <div className="text-center mb-12 mt-4">
+        <div className="text-center mb-6 mt-2 sm:mb-12 sm:mt-4">
           <p className="text-gray-400 text-sm">Creative tools and games by William Martin</p>
         </div>
 
@@ -161,15 +161,15 @@ export default function HomePage() {
                 className={`p-6 rounded-xl border ${colors.border} bg-white/5`}
               >
                 <h2 className="text-lg font-medium mb-1" style={{ color: SECTION_ACCENTS[cat.title] }}>{cat.title}</h2>
-                <p className="text-gray-400 text-sm leading-relaxed mb-3">{cat.description}</p>
+                <p className="hidden sm:block text-gray-400 text-sm leading-relaxed mb-3">{cat.description}</p>
 
                 {/* Action links */}
-                <div className="flex flex-wrap gap-2 mb-1">
+                <div className="grid grid-cols-2 gap-2 mb-1 sm:grid-cols-none sm:flex sm:flex-wrap">
                   {cat.links.map((link) => (
                     <Link
                       key={link.label}
                       href={link.href}
-                      className="flex-1 basis-[140px] min-w-[130px] px-3 py-3 rounded-lg text-sm text-left text-[#bca6f7] bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.26)] hover:bg-[rgba(167,139,250,0.16)] hover:border-[rgba(167,139,250,0.5)] transition-colors"
+                      className="max-sm:last:odd:col-span-2 flex-1 basis-[140px] min-w-[130px] px-3 py-3 rounded-lg text-sm text-left text-[#bca6f7] bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.26)] hover:bg-[rgba(167,139,250,0.16)] hover:border-[rgba(167,139,250,0.5)] transition-colors"
                     >
                       {link.label}
                     </Link>
@@ -197,7 +197,7 @@ export default function HomePage() {
                 </a>
               ))}
             </div>
-            <div className="space-y-1.5">
+            <div className="hidden sm:block space-y-1.5">
               <AdminSection
                 title="Permissions &amp; Access Control"
                 is_open={open_doc === 'Permissions & Access Control'}

--- a/src/app/tools/text-cleaner/layout.tsx
+++ b/src/app/tools/text-cleaner/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: '8i11 | What Am I Trying To Say',
+  title: '8i11 | Say What?',
 };
 
 export default function TextCleanerLayout({ children }: { children: React.ReactNode }) {

--- a/src/components/nav_tabs.tsx
+++ b/src/components/nav_tabs.tsx
@@ -67,7 +67,7 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
   const creative_items: NavItem[] = [
     { label: 'On This Day', href: '/creative' },
     { label: 'Archive', href: '/creative/archive' },
-    { label: 'What Am I Trying To Say', href: '/creative/text-cleaner' },
+    { label: 'Say What?', href: '/creative/text-cleaner' },
   ];
   const tools_items: NavItem[] = TOOLS.map((t) => ({ label: t.label, href: t.path }));
   const health_items: NavItem[] = [
@@ -160,7 +160,7 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
             aria-label={menu_open ? 'Close menu' : 'Open menu'}
             aria-expanded={menu_open}
             aria-controls="mobile-nav-drawer"
-            className={`md:hidden flex flex-col items-center justify-center gap-[4px] w-10 h-10 rounded-lg border ${is_light ? 'border-[#e5e0d8] bg-black/[0.02]' : 'border-white/15 bg-white/[0.04]'}`}
+            className={`md:hidden flex flex-col items-center justify-center gap-[4px] w-10 h-10 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${is_light ? 'focus-visible:outline-[#c4704b]' : 'focus-visible:outline-cyan-400'}`}
           >
             <span className={`w-[18px] h-[2px] rounded-full ${is_light ? 'bg-gray-600' : 'bg-gray-200'}`} />
             <span className={`w-[18px] h-[2px] rounded-full ${is_light ? 'bg-gray-600' : 'bg-gray-200'}`} />
@@ -168,7 +168,7 @@ export default function NavTabs({ theme = 'dark' }: NavTabsProps) {
           </button>
 
           {/* Wordmark — all breakpoints */}
-          <Link href="/" className={`text-xl font-extrabold tracking-tight ${wordmark_color} mr-1`}>
+          <Link href="/" className={`text-2xl md:text-xl font-extrabold tracking-tight ${wordmark_color} mr-1`}>
             8i11
           </Link>
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2001,7 +2001,7 @@ export async function save_strava_activities_cache(cache: StravaActivitiesCache)
 }
 
 // ============================================================================
-// Text Notes (What Am I Trying To Say saved notes)
+// Text Notes (Say What? saved notes)
 // ============================================================================
 
 export interface TextNote {


### PR DESCRIPTION
## Summary

Mobile-only polish on the landing page based on a screenshot review, plus a label rename.

- **Header**: hamburger button loses its box/border (was visually competing with section cards); gains a focus-visible ring for keyboard a11y. "8i11" wordmark bumped to `text-2xl` on mobile only (desktop stays `text-xl` so the desktop nav layout is untouched).
- **Section card links**: switch to `grid-cols-2` on mobile so links sit two-per-row instead of stacking. Trailing odd link spans both columns via `max-sm:last:odd:col-span-2` so 3-link sections (Creative, Games, Health) and the 1-link Weather card look intentional. Desktop `sm:flex sm:flex-wrap` behaviour preserved.
- **Section descriptions**: hidden on mobile (`hidden sm:block`) so the actual links sit higher on the page.
- **Subtitle spacing**: tightened on mobile, desktop unchanged.
- **Admin & Resources**: the four documentation disclosures (Permissions, PINs, GitHub Users, Env Vars) are hidden on mobile; the heading and quick-link pill row stay visible.
- **Rename**: "What Am I Trying To Say" → "Say What?" in all 8 user-facing and comment occurrences. URL, DB table, and API path stay the same.

## Test plan

- [ ] On mobile (~390px wide), section cards show links two-per-row; Weather's single link spans the full card width
- [ ] Section descriptions are hidden on mobile, reappear at sm: (640px+)
- [ ] Header reads as "8i11" + bare hamburger; the underline rule beneath stays
- [ ] As admin on mobile: pill links visible, four collapsible docs hidden
- [ ] `/creative/text-cleaner` H1 reads "Say What?", tab title reads "8i11 | Say What?"
- [ ] Nav drawer (hamburger → Creative) shows "Say What?"
- [ ] Desktop layout unchanged at all breakpoints ≥ sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPv4HDzwJpbceUudFQpqFD)_