### PR TITLE
Restore admin documentation disclosures on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -197,7 +197,7 @@ export default function HomePage() {
                 </a>
               ))}
             </div>
-            <div className="hidden sm:block space-y-1.5">
+            <div className="space-y-1.5">
               <AdminSection
                 title="Permissions &amp; Access Control"
                 is_open={open_doc === 'Permissions & Access Control'}


### PR DESCRIPTION
## Summary

Revert the mobile hide on the four admin documentation disclosures (Permissions & Access Control, Managing Guest PINs, Managing GitHub Users, Environment Variables Reference). They now appear on mobile again, matching the pre-#233 behaviour.

One-line change: `src/app/page.tsx:200` — remove `hidden sm:block` from the `space-y-1.5` wrapper. Everything else from #233 stays in place (header restyle, two-column link grid, section description hide, subtitle tightening, "Say What?" rename).

## Test plan

- [ ] On mobile, scroll to the bottom of the landing page; the four collapsible docs are visible below the quick-link pills
- [ ] Desktop behaviour unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPv4HDzwJpbceUudFQpqFD)_