### PR TITLE
Fix mobile horizontal overflow on weather page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import AuthSessionProvider from "@/components/session_provider";
@@ -19,6 +19,11 @@ export const metadata: Metadata = {
     default: '8i11',
   },
   description: "Creative tools and games by William Martin",
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/app/weather/page.tsx
+++ b/src/app/weather/page.tsx
@@ -179,8 +179,9 @@ export default function WeatherPage() {
       fontFamily: 'system-ui, -apple-system, sans-serif',
       display: 'flex',
       flexDirection: 'column',
-      padding: '1.5rem 2rem',
+      padding: 'clamp(1rem, 4vw, 1.5rem) clamp(1rem, 5vw, 2rem)',
       boxSizing: 'border-box',
+      overflowX: 'hidden' as const,
     },
     header: {
       display: 'flex',
@@ -203,7 +204,7 @@ export default function WeatherPage() {
     current_section: {
       display: 'flex',
       alignItems: 'center',
-      gap: '2.5rem',
+      gap: 'clamp(1rem, 4vw, 2.5rem)',
       marginBottom: '2rem',
       flexWrap: 'wrap',
     },
@@ -213,7 +214,7 @@ export default function WeatherPage() {
       alignItems: 'flex-start',
     },
     current_temp: {
-      fontSize: '9rem',
+      fontSize: 'clamp(3.5rem, 16vw, 9rem)',
       fontWeight: '800',
       lineHeight: '1',
       color: '#fff',
@@ -230,11 +231,11 @@ export default function WeatherPage() {
       gap: '0.5rem',
     },
     condition_emoji: {
-      fontSize: '5rem',
+      fontSize: 'clamp(2.5rem, 9vw, 5rem)',
       lineHeight: '1',
     },
     condition_text: {
-      fontSize: '1.75rem',
+      fontSize: 'clamp(1.1rem, 4vw, 1.75rem)',
       fontWeight: '600',
       color: '#e0e0e0',
     },
@@ -300,11 +301,14 @@ export default function WeatherPage() {
       marginTop: '0.2rem',
     },
     daily_row: {
-      display: 'grid',
-      gridTemplateColumns: 'repeat(7, 1fr)',
+      display: 'flex',
       gap: '0.75rem',
+      overflowX: 'auto' as const,
+      paddingBottom: '0.5rem',
     },
     daily_card: {
+      flex: '1 1 5.5rem',
+      minWidth: '5.5rem',
       backgroundColor: '#1e1e1e',
       borderRadius: '0.75rem',
       padding: '1rem 0.75rem',


### PR DESCRIPTION
Fixes horizontal overflow on the weather page at phone widths.

## Root cause
Missing `viewport` meta tag in `layout.tsx` — mobile browsers rendered at desktop width then scaled down.

## Changes
- Add `viewport: { width: 'device-width', initialScale: 1 }` to `layout.tsx`
- `clamp()` for temp / emoji / condition font sizes and container padding
- 7-day forecast grid → scrollable flex row (contained horizontal scroll)

## Verification (headless Chromium, production build)
Page-level horizontal overflow = **0px** at 390px, 412px, and 1280px (desktop unchanged). All elements extending past the viewport are inside `overflow-x: auto` forecast strips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)