### PR TITLE
Upgrade Sonnet 4.6 to Sonnet 5 with thinking-off parity

### DIFF
--- a/src/app/api/clean-text/route.ts
+++ b/src/app/api/clean-text/route.ts
@@ -1,6 +1,6 @@
 /**
  * API route: POST /api/clean-text
- * Uses Sonnet 4.5 to clean up rough text for clarity and readability
+ * Uses Sonnet (see MODELS.CLEAN_TEXT) to clean up rough text for clarity and readability
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -145,7 +145,8 @@ captions
 
       const substack_result = await client.messages.create({
         model: MODELS.SUBSTACK,
-        max_tokens: 8000,
+        max_tokens: 10000,
+        thinking: { type: 'disabled' },
         messages: [{ role: 'user', content: content_blocks }],
       });
 
@@ -213,7 +214,8 @@ ${content}`;
 
     const result = await client.messages.create({
       model: MODELS.CLEAN_TEXT,
-      max_tokens: 4096,
+      max_tokens: 6144,
+      thinking: { type: 'disabled' },
       messages: [{ role: 'user', content: prompt_text }],
     });
 

--- a/src/app/api/coaching/chat/route.ts
+++ b/src/app/api/coaching/chat/route.ts
@@ -100,7 +100,8 @@ export async function POST(request: NextRequest) {
 
     const response = await client.messages.create({
       model: MODELS.COACHING_DAILY,
-      max_tokens: 800,
+      max_tokens: 1024,
+      thinking: { type: 'disabled' },
       system: system_blocks,
       messages,
     });

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -149,7 +149,8 @@ ${formatted_posts}`;
 
     const message = await client.messages.create({
       model: MODELS.STORY_GENERATION,
-      max_tokens: 8192,
+      max_tokens: 11000,
+      thinking: { type: 'disabled' },
       system: [
         {
           type: 'text',

--- a/src/app/api/intro/route.ts
+++ b/src/app/api/intro/route.ts
@@ -1,6 +1,6 @@
 /**
  * API route: POST /api/intro
- * Generates a short intro paragraph for the copy feature using Haiku (fast & cheap)
+ * Generates a short intro paragraph for the copy feature using Sonnet (see MODELS.INTRO)
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -65,7 +65,8 @@ Output ONLY the intro, nothing else.`;
 
     const message = await client.messages.create({
       model: MODELS.INTRO,
-      max_tokens: 150,
+      max_tokens: 256,
+      thinking: { type: 'disabled' },
       messages: [
         { role: 'user', content: prompt }
       ]

--- a/src/app/api/knowledge-diff/route.ts
+++ b/src/app/api/knowledge-diff/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { step = 'analyze', old_doc, new_doc, analysis, use_opus } = body;
+    const { step = 'analyze', old_doc, new_doc, analysis } = body;
 
     // Size limit: 200KB per document
     const MAX_DOC_LENGTH = 200000;
@@ -82,7 +82,8 @@ ${new_doc}`;
 
       const result = await client.messages.create({
         model: MODELS.KNOWLEDGE_DIFF,
-        max_tokens: 8192,
+        max_tokens: 11000,
+        thinking: { type: 'disabled' },
         messages: [{ role: 'user', content: prompt }]
       });
 
@@ -127,8 +128,6 @@ ${new_doc}`;
         );
       }
 
-      const model = use_opus ? MODELS.KNOWLEDGE_DIFF : MODELS.KNOWLEDGE_DIFF;
-
       // Prompt Library: "Knowledge Diff - Appendix" — update library if this changes
       const prompt = `Write an appendix ONLY for facts that are VERIFIED missing from NEW.
 
@@ -158,8 +157,9 @@ OLD DOCUMENT (source for exact quotes):
 ${old_doc}`;
 
       const result = await client.messages.create({
-        model,
-        max_tokens: 8192,
+        model: MODELS.KNOWLEDGE_DIFF,
+        max_tokens: 11000,
+        thinking: { type: 'disabled' },
         messages: [{ role: 'user', content: prompt }]
       });
 

--- a/src/app/api/prompts/review/route.ts
+++ b/src/app/api/prompts/review/route.ts
@@ -45,7 +45,8 @@ export async function POST(request: NextRequest) {
     // Prompt Library: "Prompt Review" — update library if this changes
     const review = await client.messages.create({
       model: MODELS.PROMPT_REVIEW,
-      max_tokens: 2048,
+      max_tokens: 3072,
+      thinking: { type: 'disabled' },
       messages: [
         {
           role: 'user',

--- a/src/app/tools/knowledge-diff/page.tsx
+++ b/src/app/tools/knowledge-diff/page.tsx
@@ -28,7 +28,6 @@ interface DiffResult {
 export default function KnowledgeDiffPage() {
   const [old_doc, set_old_doc] = useState('');
   const [new_doc, set_new_doc] = useState('');
-  const [use_opus, set_use_opus] = useState(false);
   const [status, set_status] = useState('');  // '' | 'Analyzing...' | 'Generating appendix...'
   const [result, set_result] = useState<DiffResult | null>(null);
   const [error, set_error] = useState('');
@@ -114,8 +113,7 @@ export default function KnowledgeDiffPage() {
       const appendix_result = await api_call({
         step: 'appendix',
         old_doc,
-        analysis: analysis_result.analysis,
-        use_opus
+        analysis: analysis_result.analysis
       });
 
       combined_usage.appendix_input = appendix_result.usage.input;
@@ -143,16 +141,9 @@ export default function KnowledgeDiffPage() {
   }
 
   function calculate_cost(usage: UsageInfo): string {
-    // Sonnet: $3/M in, $15/M out; Opus: $15/M in, $75/M out
+    // Sonnet: $3/M in, $15/M out
     const analysis_cost = (usage.analysis_input * 3 + usage.analysis_output * 15) / 1_000_000;
-    let appendix_cost = 0;
-    if (usage.appendix_input > 0) {
-      if (use_opus) {
-        appendix_cost = (usage.appendix_input * 15 + usage.appendix_output * 75) / 1_000_000;
-      } else {
-        appendix_cost = (usage.appendix_input * 3 + usage.appendix_output * 15) / 1_000_000;
-      }
-    }
+    const appendix_cost = (usage.appendix_input * 3 + usage.appendix_output * 15) / 1_000_000;
     return (analysis_cost + appendix_cost).toFixed(4);
   }
 
@@ -288,23 +279,6 @@ export default function KnowledgeDiffPage() {
             Clear
           </button>
 
-          <label
-            className="knowledge-diff-option"
-            style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            color: '#bbb',
-            cursor: 'pointer'
-          }}>
-            <input
-              type="checkbox"
-              checked={use_opus}
-              onChange={(e) => set_use_opus(e.target.checked)}
-              style={{ width: '16px', height: '16px' }}
-            />
-            Use Opus 4.5 for appendix (highest quality, ~5x cost)
-          </label>
         </div>
 
         {/* Error */}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,14 +1,17 @@
-// Last reviewed: April 2026
-// Sonnet 4.6 dated snapshot (claude-sonnet-4-6-20260217) returns 404 from the API;
-// using the bare alias for Sonnet 4.6 which is the documented entry point.
+// Last reviewed: July 2026
+// Sonnet 5 uses the bare documented alias 'claude-sonnet-5' — dated snapshots
+// (e.g. claude-sonnet-4-6-20260217) 404 from the API, so never append a date.
+// Sonnet 5 runs adaptive thinking by default when `thinking` is omitted;
+// routes pass `thinking: { type: 'disabled' }` for parity with the old
+// Sonnet 4.6 thinking-off behavior.
 export const MODELS = {
-  STORY_GENERATION: 'claude-sonnet-4-6',
-  KNOWLEDGE_DIFF:   'claude-sonnet-4-6',
-  INTRO:            'claude-sonnet-4-6',
-  PROMPT_REVIEW:    'claude-sonnet-4-6',
-  CLEAN_TEXT:       'claude-sonnet-4-6',
+  STORY_GENERATION: 'claude-sonnet-5',
+  KNOWLEDGE_DIFF:   'claude-sonnet-5',
+  INTRO:            'claude-sonnet-5',
+  PROMPT_REVIEW:    'claude-sonnet-5',
+  CLEAN_TEXT:       'claude-sonnet-5',
   STRIP:            'claude-haiku-4-5-20251001',
-  SUBSTACK:         'claude-sonnet-4-6',
-  COACHING_DAILY:   'claude-sonnet-4-6',
+  SUBSTACK:         'claude-sonnet-5',
+  COACHING_DAILY:   'claude-sonnet-5',
   COACHING_REFINE:  'claude-haiku-4-5-20251001',
 }


### PR DESCRIPTION
## What changed

- **`src/lib/models.ts`**: the seven Sonnet tasks move from `claude-sonnet-4-6` to `claude-sonnet-5` (bare documented alias — no date suffix; dated snapshots 404). The two Haiku 4.5 entries are unchanged.
- **8 API call sites** now pass `thinking: { type: 'disabled' }`. On Sonnet 5, omitting the `thinking` parameter runs adaptive thinking by default, and thinking tokens count against `max_tokens` — the tight budgets (intro: 150, coaching: 800) would have truncated responses. Disabling it preserves current behavior exactly.
- **`max_tokens` raised ~30%** on Sonnet routes (generate 8192→11000, intro 150→256, etc.) because Sonnet 5's tokenizer produces ~30% more tokens for the same text. Pure headroom, no cost impact unless output actually grows.
- **Dead `use_opus` path removed** from knowledge-diff: the backend ternary never switched models, and the UI checkbox misreported cost at Opus pricing (~5×) for what was always a Sonnet call. Checkbox, request field, and cost branch are all gone.
- Two stale route header comments fixed (clean-text claimed "Sonnet 4.5", intro claimed "Haiku").

## Testing

- `npm run build`, `npm run lint`, and `npx vitest` (38 tests) all pass.
- Verified live on the Vercel preview: story generation, text cleaning, and knowledge diff all ran correctly with no truncated output (truncation is the failure signature of this migration).

## Notes

- Cost: Sonnet 5 has introductory pricing of $2/$10 per MTok through 2026-08-31, then matches Sonnet 4.6's $3/$15 — cheaper until September, flat after.
- Rollback: revert this single commit; Sonnet 4.6 remains an active model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191K3wF2uQwHhpgXAy35ScV

---
_Generated by [Claude Code](https://claude.ai/code/session_0191K3wF2uQwHhpgXAy35ScV)_