### PR TITLE
Coach page: fill metric grid on mobile, tap selectors for back and bowel

### DIFF
--- a/src/app/api/coaching/finalize/route.ts
+++ b/src/app/api/coaching/finalize/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       advice_full: string;
       conversation_turns: number;
       token_count: number;
-      manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string };
+      manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; bowel_scale?: number; injury_notes?: string };
       data_snapshot?: string;
       inject_metrics?: InjectMetrics;
     };

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -727,37 +727,27 @@ export default function CoachPage() {
                   </div>
                 </div>
 
-                {/* Physiology row: 3 + 2 full-width rows on phones, single row of 5 on desktop */}
-                <div className="grid grid-cols-6 md:grid-cols-10 gap-2">
-                  <MetricCard label="HRV" value={metrics.hrv} unit="ms" trend={trends['hrv']} sparkline={sparklines['hrv']} href="/coach/metric/hrv" className="col-span-2" />
-                  <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" trend={trends['resting-hr']} sparkline={sparklines['resting-hr']} href="/coach/metric/resting-hr" className="col-span-2" />
-                  <MetricCard label="Blood Oxygen" value={metrics.spo2 ? Math.round(metrics.spo2) : null} unit="%" trend={trends['spo2']} sparkline={sparklines['spo2']} href="/coach/metric/spo2" className="col-span-2" />
-                  <MetricCard label="CV Age" value={metrics.cv_age} unit="yr" trend={trends['cv-age']} sparkline={sparklines['cv-age']} href="/coach/metric/cv-age" className="col-span-3 md:col-span-2" />
-                  <MetricCard label="Weight" value={metrics.weight} unit="lbs" warn={metrics.weight_stale} trend={trends['weight']} sparkline={sparklines['weight']} href="/coach/metric/weight" className="col-span-3 md:col-span-2" />
-                </div>
-
-                {/* Resilience / Stress-Recovery */}
-                {(metrics.stress_min != null && metrics.restored_min != null) && (
-                  <div className={`bg-zinc-900 border rounded-lg px-3 py-2 ${
-                    metrics.resilience?.includes('High recovery') ? 'border-green-800' :
-                    metrics.resilience?.includes('Balanced') ? 'border-zinc-700' :
-                    metrics.resilience?.includes('Elevated') ? 'border-yellow-700' :
-                    metrics.resilience?.includes('High stress') ? 'border-red-800' :
-                    'border-zinc-800'
-                  }`}>
-                    <div className="flex justify-between items-baseline">
-                      <div>
-                        <div className="text-xs text-gray-500">Resilience</div>
-                        <div className="text-sm font-medium text-white">{metrics.resilience || 'No stress data yet'}</div>
-                      </div>
-                      <div className="text-right text-xs text-gray-500">
-                        <span>{metrics.stress_min}m stressed</span>
-                        <span> · </span>
-                        <span>{metrics.restored_min}m restored</span>
-                      </div>
+                {/* Physiology: six equal tiles, two rows of three on phones */}
+                <div className="grid grid-cols-3 md:grid-cols-6 gap-2">
+                  <MetricCard label="HRV" value={metrics.hrv} unit="ms" trend={trends['hrv']} sparkline={sparklines['hrv']} href="/coach/metric/hrv" />
+                  <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" trend={trends['resting-hr']} sparkline={sparklines['resting-hr']} href="/coach/metric/resting-hr" />
+                  <MetricCard label="Blood Oxygen" value={metrics.spo2 ? Math.round(metrics.spo2) : null} unit="%" trend={trends['spo2']} sparkline={sparklines['spo2']} href="/coach/metric/spo2" />
+                  <MetricCard label="CV Age" value={metrics.cv_age} unit="yr" trend={trends['cv-age']} sparkline={sparklines['cv-age']} href="/coach/metric/cv-age" />
+                  <MetricCard label="Weight" value={metrics.weight} unit="lbs" warn={metrics.weight_stale} trend={trends['weight']} sparkline={sparklines['weight']} href="/coach/metric/weight" />
+                  {(metrics.stress_min != null && metrics.restored_min != null) && (
+                    <div className={`h-full flex flex-col bg-zinc-900 border rounded-lg px-3 py-2 ${
+                      metrics.resilience?.includes('High recovery') ? 'border-green-800' :
+                      metrics.resilience?.includes('Balanced') ? 'border-zinc-700' :
+                      metrics.resilience?.includes('Elevated') ? 'border-yellow-700' :
+                      metrics.resilience?.includes('High stress') ? 'border-red-800' :
+                      'border-zinc-800'
+                    }`}>
+                      <div className="text-xs text-gray-500 truncate">Resilience</div>
+                      <div className="text-sm font-medium text-white">{metrics.resilience || 'No stress data yet'}</div>
+                      <div className="mt-auto text-xs text-gray-500">{metrics.stress_min}m / {metrics.restored_min}m</div>
                     </div>
-                  </div>
-                )}
+                  )}
+                </div>
 
                 {/* Yesterday's Activities */}
                 {metrics.yesterday_activities && metrics.yesterday_activities.length > 0 && (

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -100,7 +100,7 @@ function Sparkline({ data }: { data: (number | null)[] }) {
   );
 }
 
-function MetricCard({ label, value, unit, warn, trend, sparkline, href }: { label: string; value: unknown; unit?: string; warn?: boolean; trend?: TrendInfo; sparkline?: (number | null)[]; href?: string }) {
+function MetricCard({ label, value, unit, warn, trend, sparkline, href, className }: { label: string; value: unknown; unit?: string; warn?: boolean; trend?: TrendInfo; sparkline?: (number | null)[]; href?: string; className?: string }) {
   if (value === null || value === undefined) return null;
   const content = (
     <div className={`h-full flex flex-col bg-zinc-900 border ${warn ? 'border-yellow-600' : 'border-zinc-800'} rounded-lg px-3 py-2 ${href ? 'cursor-pointer hover:border-zinc-600 transition-colors' : ''}`}>
@@ -113,9 +113,9 @@ function MetricCard({ label, value, unit, warn, trend, sparkline, href }: { labe
     </div>
   );
   if (href) {
-    return <Link href={href} className="h-full">{content}</Link>;
+    return <Link href={href} className={`h-full ${className ?? ''}`}>{content}</Link>;
   }
-  return content;
+  return <div className={`h-full ${className ?? ''}`}>{content}</div>;
 }
 
 function ActivityRow({ activity }: { activity: Metrics['yesterday_activities'] extends (infer T)[] | undefined ? T : never }) {
@@ -138,14 +138,49 @@ function ActivityRow({ activity }: { activity: Metrics['yesterday_activities'] e
   );
 }
 
+// Tap-selector levels (roadmap: numeric behind the scenes, unset saves null)
+const BACK_LEVELS = [
+  { label: 'None', value: 0 },
+  { label: 'Mild', value: 3 },
+  { label: 'Moderate', value: 6 },
+  { label: 'Severe', value: 9 },
+];
+
+const BOWEL_LEVELS = [
+  { label: 'Loose', value: 1 },
+  { label: 'Normal', value: 2 },
+  { label: 'Hard', value: 3 },
+  { label: 'None', value: 0 },
+];
+
+function LevelSelector({ options, value, onChange }: { options: { label: string; value: number }[]; value: number | null; onChange: (v: number | null) => void }) {
+  return (
+    <div className="grid grid-cols-4 gap-1">
+      {options.map(o => (
+        <button
+          key={o.label}
+          type="button"
+          onClick={() => onChange(value === o.value ? null : o.value)}
+          className={`py-2 rounded text-sm transition-colors ${
+            value === o.value
+              ? 'bg-blue-600 text-white'
+              : 'bg-zinc-900 border border-zinc-700 text-gray-400 hover:text-white'
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export default function CoachPage() {
   useEffect(() => { document.title = '8i11 | Coach'; }, []);
 
-  // Manual inputs
+  // Manual inputs — selectors start unset so an untouched input saves null
   const [weight, setWeight] = useState('');
-  const [backPain, setBackPain] = useState(0);
-  const [backNotes, setBackNotes] = useState('');
-  const [bowel, setBowel] = useState('');
+  const [backPain, setBackPain] = useState<number | null>(null);
+  const [bowel, setBowel] = useState<number | null>(null);
   const [injuries, setInjuries] = useState('');
 
   // Data state
@@ -376,9 +411,9 @@ export default function CoachPage() {
           epoch_day: epochDay,
           manual: {
             weight_lbs: weight ? parseFloat(weight) : undefined,
-            back_pain_scale: backPain,
-            back_mobility_notes: backNotes || undefined,
-            bowel_status: bowel || undefined,
+            back_pain_scale: backPain ?? undefined,
+            bowel_status: bowel != null ? BOWEL_LEVELS.find(o => o.value === bowel)?.label : undefined,
+            bowel_scale: bowel ?? undefined,
             injury_notes: injuries || undefined,
           },
           oura_live: ouraData?.success ? ouraData : undefined,
@@ -485,9 +520,9 @@ export default function CoachPage() {
           data_snapshot: dataInjection,
           manual: {
             weight_lbs: weight ? parseFloat(weight) : undefined,
-            back_pain_scale: backPain,
-            back_mobility_notes: backNotes || undefined,
-            bowel_status: bowel || undefined,
+            back_pain_scale: backPain ?? undefined,
+            bowel_status: bowel != null ? BOWEL_LEVELS.find(o => o.value === bowel)?.label : undefined,
+            bowel_scale: bowel ?? undefined,
             injury_notes: injuries || undefined,
           },
           inject_metrics: metrics ? {
@@ -630,7 +665,7 @@ export default function CoachPage() {
         )}
 
         {/* Pre-Chat: Metrics Pane */}
-        <div className="space-y-5 mb-5">
+        <div className="space-y-4 mb-5">
             {/* Once a session starts, metrics collapse behind this header */}
             {sessionStarted && (
               <button
@@ -692,13 +727,13 @@ export default function CoachPage() {
                   </div>
                 </div>
 
-                {/* Physiology row */}
-                <div className="grid grid-cols-3 md:grid-cols-5 gap-2">
-                  <MetricCard label="HRV" value={metrics.hrv} unit="ms" trend={trends['hrv']} sparkline={sparklines['hrv']} href="/coach/metric/hrv" />
-                  <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" trend={trends['resting-hr']} sparkline={sparklines['resting-hr']} href="/coach/metric/resting-hr" />
-                  <MetricCard label="Blood Oxygen" value={metrics.spo2 ? Math.round(metrics.spo2) : null} unit="%" trend={trends['spo2']} sparkline={sparklines['spo2']} href="/coach/metric/spo2" />
-                  <MetricCard label="CV Age" value={metrics.cv_age} unit="yr" trend={trends['cv-age']} sparkline={sparklines['cv-age']} href="/coach/metric/cv-age" />
-                  <MetricCard label="Weight" value={metrics.weight} unit="lbs" warn={metrics.weight_stale} trend={trends['weight']} sparkline={sparklines['weight']} href="/coach/metric/weight" />
+                {/* Physiology row: 3 + 2 full-width rows on phones, single row of 5 on desktop */}
+                <div className="grid grid-cols-6 md:grid-cols-10 gap-2">
+                  <MetricCard label="HRV" value={metrics.hrv} unit="ms" trend={trends['hrv']} sparkline={sparklines['hrv']} href="/coach/metric/hrv" className="col-span-2" />
+                  <MetricCard label="Resting HR" value={metrics.resting_hr} unit="bpm" trend={trends['resting-hr']} sparkline={sparklines['resting-hr']} href="/coach/metric/resting-hr" className="col-span-2" />
+                  <MetricCard label="Blood Oxygen" value={metrics.spo2 ? Math.round(metrics.spo2) : null} unit="%" trend={trends['spo2']} sparkline={sparklines['spo2']} href="/coach/metric/spo2" className="col-span-2" />
+                  <MetricCard label="CV Age" value={metrics.cv_age} unit="yr" trend={trends['cv-age']} sparkline={sparklines['cv-age']} href="/coach/metric/cv-age" className="col-span-3 md:col-span-2" />
+                  <MetricCard label="Weight" value={metrics.weight} unit="lbs" warn={metrics.weight_stale} trend={trends['weight']} sparkline={sparklines['weight']} href="/coach/metric/weight" className="col-span-3 md:col-span-2" />
                 </div>
 
                 {/* Resilience / Stress-Recovery */}
@@ -741,56 +776,34 @@ export default function CoachPage() {
             {!sessionStarted && (<>
             {/* Manual Inputs */}
             <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-xs text-gray-500 mb-1">Weight (lbs)</label>
-                  <input
-                    type="number"
-                    value={weight}
-                    onChange={e => setWeight(e.target.value)}
-                    placeholder="e.g. 192"
-                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-xs text-gray-500 mb-1">Back Pain: {backPain}/10</label>
-                  <input
-                    type="range"
-                    min="0"
-                    max="10"
-                    value={backPain}
-                    onChange={e => setBackPain(parseInt(e.target.value))}
-                    className="w-full mt-2"
-                  />
-                </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Weight (lbs)</label>
+                <input
+                  type="number"
+                  value={weight}
+                  onChange={e => setWeight(e.target.value)}
+                  placeholder="e.g. 192"
+                  className="w-1/2 bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                />
               </div>
-
-              <details className="text-sm">
-                <summary className="text-gray-500 cursor-pointer text-xs">More inputs</summary>
-                <div className="space-y-3 mt-2">
-                  <input
-                    type="text"
-                    value={backNotes}
-                    onChange={e => setBackNotes(e.target.value)}
-                    placeholder="Back mobility notes"
-                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
-                  />
-                  <input
-                    type="text"
-                    value={bowel}
-                    onChange={e => setBowel(e.target.value)}
-                    placeholder="Bowel status"
-                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
-                  />
-                  <textarea
-                    value={injuries}
-                    onChange={e => setInjuries(e.target.value)}
-                    placeholder="Injuries or notes for today"
-                    rows={2}
-                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
-                  />
-                </div>
-              </details>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Back</label>
+                <LevelSelector options={BACK_LEVELS} value={backPain} onChange={setBackPain} />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Bowel</label>
+                <LevelSelector options={BOWEL_LEVELS} value={bowel} onChange={setBowel} />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Notes</label>
+                <textarea
+                  value={injuries}
+                  onChange={e => setInjuries(e.target.value)}
+                  placeholder="Injuries or notes for today"
+                  rows={2}
+                  className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-white text-sm"
+                />
+              </div>
             </div>
 
             {error && <p className="text-red-400 text-sm">{error}</p>}

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -12,6 +12,7 @@ export interface ManualInputs {
   back_pain_scale?: number;
   back_mobility_notes?: string;
   bowel_status?: string;
+  bowel_scale?: number;
   injury_notes?: string;
 }
 
@@ -340,9 +341,11 @@ export async function build_data_injection(
   }
 
   if (manual.back_pain_scale !== undefined) {
+    const back = manual.back_pain_scale;
+    const label = back === 0 ? 'None' : back <= 3 ? 'Mild' : back <= 6 ? 'Moderate' : 'Severe';
     const mobility = manual.back_mobility_notes ? `, ${manual.back_mobility_notes}` : '';
-    lines.push(`Back: ${manual.back_pain_scale}/10${mobility}`);
-    metrics.back_pain = manual.back_pain_scale;
+    lines.push(`Back: ${label} (${back}/10)${mobility}`);
+    metrics.back_pain = back;
   }
 
   if (manual.bowel_status) lines.push(`Bowel: ${manual.bowel_status}`);

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -23,6 +23,7 @@ const TREND_METRICS = [
   'vo2max_intervals_weekly',
   'weight_lbs',
   'back_pain_scale',
+  'bowel_scale',
 ] as const;
 
 function compute_direction(values: number[]): string {
@@ -219,7 +220,7 @@ const fin = (v: number | null | undefined): number | null =>
 export async function populate_daily_metrics(
   date_str: string,
   epoch_day: number,
-  manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; injury_notes?: string },
+  manual?: { weight_lbs?: number; back_pain_scale?: number; back_mobility_notes?: string; bowel_status?: string; bowel_scale?: number; injury_notes?: string },
   inject_metrics?: InjectMetrics,
 ): Promise<boolean> {
   await ensure_schema();
@@ -319,9 +320,9 @@ export async function populate_daily_metrics(
       hrv_rmssd, resting_hr, readiness_score, cardiovascular_age, spo2_average,
       vo2_max, training_load_acute, training_load_chronic, recovery_pct,
       zone2_min_weekly, vo2max_intervals_weekly,
-      weight_lbs, back_pain_scale, back_mobility_notes, bowel_status, injury_notes,
+      weight_lbs, back_pain_scale, back_mobility_notes, bowel_status, bowel_scale, injury_notes,
       created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       epoch_day,
       fin(sleep_duration_min), fin(sleep_efficiency_pct), fin(deep_sleep_min), fin(rem_sleep_min),
@@ -329,7 +330,7 @@ export async function populate_daily_metrics(
       fin(vo2_max), fin(training_load_acute), fin(training_load_chronic), fin(recovery_pct),
       null, null, // zone2_min_weekly, vo2max_intervals_weekly — computed separately
       fin(manual?.weight_lbs ?? null), fin(manual?.back_pain_scale ?? null),
-      manual?.back_mobility_notes ?? null, manual?.bowel_status ?? null, manual?.injury_notes ?? null,
+      manual?.back_mobility_notes ?? null, manual?.bowel_status ?? null, fin(manual?.bowel_scale ?? null), manual?.injury_notes ?? null,
       now, now,
     ],
   });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -202,6 +202,13 @@ async function init_schema(): Promise<void> {
     // Column already exists, ignore error
   }
 
+  // Migration: add bowel_scale column to daily_metrics (Loose=1 Normal=2 Hard=3 None=0)
+  try {
+    await db.execute(`ALTER TABLE daily_metrics ADD COLUMN bowel_scale INTEGER`);
+  } catch {
+    // Column already exists, ignore error
+  }
+
   // Migration: backfill cardiovascular_age from HRV + RHR where missing
   // Uses Umetani regression: cv_age = 0.65 * (107 - 12.5 * ln(HRV)) + 0.35 * (1.4 * RHR - 40)
   await db.execute(`


### PR DESCRIPTION
Implements roadmap priority 2 (input standardization, #242 decisions) plus the metric-grid rebalance, following up on PR #240 which fixed the overflow but left the wasted space and the mixed input row.

## Changes
- Physiology grid no longer leaves an empty cell on phones: HRV / Resting HR / Blood Oxygen fill the first row, CV Age / Weight stretch across the second. Desktop stays one row of five. "Blood Oxygen" now fits without truncating on mobile.
- Back Pain slider replaced with a 4-level tap selector (None / Mild / Moderate / Severe → 0/3/6/9 on the existing 0–10 scale). It starts **unset**, so an untouched input no longer saves a false 0/10 — tap the selected level again to unset it.
- Bowel free-text replaced with a 4-option tap selector (Loose / Normal / Hard / None), stored numerically in a new `daily_metrics.bowel_scale` column (catch-and-ignore ALTER) so it can trend, alongside the human-readable label in `bowel_status`.
- "More inputs" expander and the Back-mobility-notes box removed; Weight (typed, unchanged) and Notes are always visible in one clean stack.
- Data injection now sends `Back: Moderate (6/10)` instead of a bare number; bowel and notes lines unchanged.

## What to test (on the phone, Vercel preview below)
1. Open /coach: metric tiles fill the width — a row of 3, then CV Age + Weight across a full row of 2, no gap.
2. The input area: Weight box, Back selector, Bowel selector, Notes — no expander, no slider.
3. Tap "Mild" on Back, tap it again — it should deselect back to unset.
4. Start a session **without touching Back**: the injected data (first chat message) should have no "Back:" line at all.
5. Select Back + Bowel and start a session: injection shows "Back: Mild (3/10)" and "Bowel: Normal".

## Expected results
No empty grid cell on mobile, no false 0/10 back pain in saved sessions, chat and history behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnbWXKD3ueCjimEjV6jgxc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnbWXKD3ueCjimEjV6jgxc)_