### PR TITLE
Show completed-session view on coach page instead of form

### DIFF
--- a/src/app/api/coaching/today/route.ts
+++ b/src/app/api/coaching/today/route.ts
@@ -1,0 +1,30 @@
+/**
+ * API route: GET /api/coaching/today
+ * Returns the coaching session saved for today (or null) so the coach
+ * page can show the completed view instead of the start form.
+ * Accepts ?date=<epoch-day> from the client so the check uses the same
+ * day value the client sends to finalize.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { get_session_by_date } from '@/lib/coaching/db';
+
+export async function GET(request: NextRequest) {
+  const token = await getToken({ req: request });
+  if (!token) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    const param = Number(request.nextUrl.searchParams.get('date'));
+    const date = Number.isFinite(param) && param > 0 ? param : Math.floor(Date.now() / 86400000);
+    const session = await get_session_by_date(date);
+    return NextResponse.json({ session });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch today's session" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -174,6 +174,20 @@ function LevelSelector({ options, value, onChange }: { options: { label: string;
   );
 }
 
+// Split stored advice_full into its data snapshot and conversation sections
+function parseAdviceFull(adviceFull: string): { dataSnapshot: string | null; conversation: string } {
+  const hasSnapshot = adviceFull.startsWith('[Data for this session]');
+  const convoMarker = '[Conversation]';
+  const convoIdx = hasSnapshot ? adviceFull.indexOf(convoMarker) : -1;
+  const dataSnapshot = hasSnapshot && convoIdx > 0
+    ? adviceFull.slice('[Data for this session]\n'.length, convoIdx).trim()
+    : null;
+  const conversation = convoIdx > 0
+    ? adviceFull.slice(convoIdx + convoMarker.length).trim()
+    : adviceFull;
+  return { dataSnapshot, conversation };
+}
+
 export default function CoachPage() {
   useEffect(() => { document.title = '8i11 | Coach'; }, []);
 
@@ -206,6 +220,9 @@ export default function CoachPage() {
   const [metricsCollapsed, setMetricsCollapsed] = useState(false);
   const [finalized, setFinalized] = useState(false);
   const [savedSummary, setSavedSummary] = useState('');
+  const [todaySession, setTodaySession] = useState<HistorySession | null>(null);
+  const [todayChecked, setTodayChecked] = useState(false);
+  const [startNewAnyway, setStartNewAnyway] = useState(false);
   const [totalTokens, setTotalTokens] = useState(0);
   const [turnCount, setTurnCount] = useState(0);
   const chatEndRef = useRef<HTMLDivElement>(null);
@@ -385,6 +402,19 @@ export default function CoachPage() {
       }
     }
     loadMetrics();
+
+    // Check whether today's session is already saved (hides the start form)
+    async function loadTodaySession() {
+      try {
+        const res = await fetch(`/api/coaching/today?date=${epochDay}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.session) setTodaySession(data.session);
+        }
+      } catch { /* best effort — form shows as usual */ }
+      setTodayChecked(true);
+    }
+    loadTodaySession();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -548,6 +578,15 @@ export default function CoachPage() {
       const data = await res.json();
       setFinalized(true);
       setSavedSummary(data.summary || '');
+      // Mirror what finalize stored so a re-render shows the completed view
+      setTodaySession({
+        date: epochDay,
+        advice_full: dataInjection
+          ? `[Data for this session]\n${dataInjection}\n\n[Conversation]\n${adviceFull}`
+          : adviceFull,
+        advice_summary: data.summary || null,
+        conversation_turns: turnCount,
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save');
     } finally {
@@ -617,16 +656,7 @@ export default function CoachPage() {
           <div className="mb-6 space-y-2">
             {history.length === 0 && <p className="text-gray-500 text-sm">No past sessions.</p>}
             {history.map(s => {
-              // Parse data snapshot from stored advice_full
-              const hasSnapshot = s.advice_full.startsWith('[Data for this session]');
-              const convoMarker = '[Conversation]';
-              const convoIdx = hasSnapshot ? s.advice_full.indexOf(convoMarker) : -1;
-              const dataSnapshot = hasSnapshot && convoIdx > 0
-                ? s.advice_full.slice('[Data for this session]\n'.length, convoIdx).trim()
-                : null;
-              const conversation = convoIdx > 0
-                ? s.advice_full.slice(convoIdx + convoMarker.length).trim()
-                : s.advice_full;
+              const { dataSnapshot, conversation } = parseAdviceFull(s.advice_full);
 
               return (
                 <details key={s.date} className="bg-zinc-900 border border-zinc-800 rounded">
@@ -763,7 +793,38 @@ export default function CoachPage() {
               <div className="text-gray-500 text-sm">No health data available. Oura may need to sync.</div>
             ))}
 
-            {!sessionStarted && (<>
+            {/* Completed session: synopsis + transcript instead of the form */}
+            {!sessionStarted && todaySession && !startNewAnyway && (
+              <div className="space-y-3">
+                <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-white">Today&apos;s session</span>
+                    <span className="text-xs text-green-400">✓ Complete</span>
+                  </div>
+                  {todaySession.advice_summary ? (
+                    <p className="text-sm text-gray-300">{todaySession.advice_summary}</p>
+                  ) : (
+                    <p className="text-sm text-gray-500">Session saved — no summary was generated.</p>
+                  )}
+                  <details className="text-xs">
+                    <summary className="text-gray-500 cursor-pointer">Full conversation</summary>
+                    <div className="mt-1 text-gray-400 whitespace-pre-wrap">{parseAdviceFull(todaySession.advice_full).conversation}</div>
+                  </details>
+                </div>
+                <button
+                  onClick={() => setStartNewAnyway(true)}
+                  className="text-xs text-gray-500 hover:text-gray-300 underline decoration-zinc-700 transition-colors"
+                >
+                  Start a new session
+                </button>
+              </div>
+            )}
+
+            {!sessionStarted && todayChecked && (!todaySession || startNewAnyway) && (<>
+            {startNewAnyway && (
+              <p className="text-xs text-yellow-500">Saving a new session will replace today&apos;s saved session.</p>
+            )}
+
             {/* Manual Inputs */}
             <div className="space-y-3">
               <div>

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -390,3 +390,25 @@ export async function get_recent_sessions(limit: number = 3, offset: number = 0)
     created_at: Number(row.created_at),
   }));
 }
+
+/**
+ * Get the coaching session saved for a specific epoch-day, if any.
+ */
+export async function get_session_by_date(date: number): Promise<CoachingSession | null> {
+  await ensure_schema();
+  const db = get_client();
+  const result = await db.execute({
+    sql: `SELECT date, advice_full, advice_summary, conversation_turns, created_at
+          FROM coaching_history WHERE date = ?`,
+    args: [date],
+  });
+  if (result.rows.length === 0) return null;
+  const row = result.rows[0];
+  return {
+    date: Number(row.date),
+    advice_full: row.advice_full as string,
+    advice_summary: (row.advice_summary as string) ?? null,
+    conversation_turns: Number(row.conversation_turns),
+    created_at: Number(row.created_at),
+  };
+}


### PR DESCRIPTION
## What

Returning to `/coach` after saving today's session no longer shows the start form. Instead the page shows the usual live metrics pane plus a **"Today's session ✓ Complete"** card with the coach's saved synopsis and a collapsible full-conversation transcript (same pattern as history items). A small "Start a new session" link remains below the card, with a warning that saving a new session replaces today's saved one — this matches the existing DB behavior (`coaching_history.date` is UNIQUE with `INSERT OR REPLACE`, so a second save always overwrote silently).

## Changes

- `src/app/api/coaching/today/route.ts` — new `GET` endpoint returning today's saved session (or null); accepts `?date=<epoch-day>` from the client so the check uses the same day value the client sends to finalize
- `src/lib/coaching/db.ts` — new `get_session_by_date()` helper
- `src/app/coach/page.tsx` — today-session check on mount, completed-session card, override link + warning, and deduplicated the `advice_full` snapshot/conversation parsing shared with the history list

## What to test (Vercel preview)

1. With no session saved today, `/coach` shows the metrics + form exactly as before.
2. Complete and save a session, then reload `/coach` — expected: no form; metrics pane, "Today's session ✓ Complete" card with the synopsis, and an expandable "Full conversation".
3. Click "Start a new session" — expected: yellow warning ("Saving a new session will replace today's saved session") and the normal form; completing and saving replaces today's entry (History still shows one entry for the day).
4. Guests remain blocked from `/coach` and `/api/coaching/*` (unchanged middleware).

Note: the day boundary is UTC-based, consistent with how finalize already dates sessions.

Verified locally end-to-end (dev server + Chromium): completed view, transcript expand, override flow, single-row overwrite on second save, and fresh-day form all pass. `npm run build`, `npm run lint`, `npx vitest` (38 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3HsqMsJbCcYB3a8RZMmKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3HsqMsJbCcYB3a8RZMmKr)_