### PR TITLE
Land Mountain Time coach day boundary + document Vercel CLI access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 **Live:** https://8i11.vercel.app | **Repo:** https://github.com/boneshakerbike/onthisday
 
+> **Vercel access:** Use the `vercel` CLI (already installed, logged in as `boneshakerbike`, team `boneshakerbikes-projects`). Do NOT use the Vercel MCP plugin — its OAuth redirect is broken on Vercel's side and will error. The `/doctor` MCP auth warning at login is cosmetic; ignore it. Examples: `vercel projects ls`, `vercel ls`, `vercel logs <url>`, `vercel env ls`.
+
 ## Tech Stack
 
 | Category | Technology |

--- a/src/app/api/coaching/metrics/[slug]/route.ts
+++ b/src/app/api/coaching/metrics/[slug]/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { get_client, ensure_schema } from '@/lib/db';
 import { getMetricBySlug } from '@/lib/coaching/metric-config';
+import { mt_epoch_day, epoch_day_to_date_str } from '@/lib/coaching/day';
 
 export async function GET(
   request: NextRequest,
@@ -31,7 +32,7 @@ export async function GET(
   try {
     await ensure_schema();
     const db = get_client();
-    const today = Math.floor(Date.now() / 86400000);
+    const today = mt_epoch_day();
     const startDate = today - days;
 
     const result = await db.execute({
@@ -43,7 +44,7 @@ export async function GET(
       .filter(r => r.value != null)
       .map(r => ({
         date: Number(r.date),
-        dateStr: new Date(Number(r.date) * 86400000).toISOString().split('T')[0],
+        dateStr: epoch_day_to_date_str(Number(r.date)),
         value: Number(r.value),
       }));
 

--- a/src/app/api/coaching/today/route.ts
+++ b/src/app/api/coaching/today/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { get_session_by_date } from '@/lib/coaching/db';
+import { mt_epoch_day } from '@/lib/coaching/day';
 
 export async function GET(request: NextRequest) {
   const token = await getToken({ req: request });
@@ -18,7 +19,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const param = Number(request.nextUrl.searchParams.get('date'));
-    const date = Number.isFinite(param) && param > 0 ? param : Math.floor(Date.now() / 86400000);
+    const date = Number.isFinite(param) && param > 0 ? param : mt_epoch_day();
     const session = await get_session_by_date(date);
     return NextResponse.json({ session });
   } catch (error) {

--- a/src/app/api/coaching/trends/route.ts
+++ b/src/app/api/coaching/trends/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { compute_trends, cleanup_trend_cache, cleanup_daily_metrics, populate_daily_metrics } from '@/lib/coaching/db';
+import { mt_epoch_day, epoch_day_to_date_str } from '@/lib/coaching/day';
 
 export async function GET(request: NextRequest) {
   // Verify cron secret (Vercel sends this automatically for cron jobs)
@@ -16,13 +17,12 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const today = Math.floor(Date.now() / 86400000);
+    const today = mt_epoch_day();
 
     // Populate daily_metrics from cached Oura + COROS for yesterday
-    // (cron runs at 9am UTC, so yesterday's data is complete)
+    // (cron runs at 9am UTC = 2-3am MT, so yesterday's data is complete)
     const yesterday_epoch = today - 1;
-    const yesterday_date = new Date((yesterday_epoch) * 86400000);
-    const yesterday_str = yesterday_date.toISOString().split('T')[0];
+    const yesterday_str = epoch_day_to_date_str(yesterday_epoch);
     const populated = await populate_daily_metrics(yesterday_str, yesterday_epoch);
 
     const trend_result = await compute_trends(today);

--- a/src/app/api/coaching/trends/today/route.ts
+++ b/src/app/api/coaching/trends/today/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { get_client, ensure_schema } from '@/lib/db';
 import { METRIC_CONFIG, computeTrend, type MetricTrend } from '@/lib/coaching/metric-config';
+import { mt_epoch_day } from '@/lib/coaching/day';
 
 export async function POST(request: NextRequest) {
   const token = await getToken({ req: request });
@@ -19,7 +20,7 @@ export async function POST(request: NextRequest) {
   try {
     await ensure_schema();
     const db = get_client();
-    const today = Math.floor(Date.now() / 86400000);
+    const today = mt_epoch_day();
     const yesterday = today - 1;
     const now = Math.floor(Date.now() / 1000);
 

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -10,6 +10,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import NavTabs from '@/components/nav_tabs';
+import { mt_date_str, mt_epoch_day, epoch_day_to_date_str } from '@/lib/coaching/day';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -227,9 +228,9 @@ export default function CoachPage() {
   const [turnCount, setTurnCount] = useState(0);
   const chatEndRef = useRef<HTMLDivElement>(null);
 
-  const today = new Date();
-  const dateStr = today.toLocaleDateString('en-CA');
-  const epochDay = Math.floor(Date.now() / 86400000);
+  // Day boundary is Mountain Time regardless of where the client runs
+  const dateStr = mt_date_str();
+  const epochDay = mt_epoch_day();
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -262,9 +263,7 @@ export default function CoachPage() {
         const stravaData = stravaRes?.ok ? await stravaRes.json() : null;
 
         // Build a preview injection to get metrics
-        const yesterday = new Date(today);
-        yesterday.setDate(yesterday.getDate() - 1);
-        const yesterdayStr = yesterday.toLocaleDateString('en-CA');
+        const yesterdayStr = epoch_day_to_date_str(epochDay - 1);
 
         // Extract yesterday's activities from Strava
         const stravaActivities = stravaData?.activities?.filter(
@@ -623,10 +622,6 @@ export default function CoachPage() {
     setHistoryLoadingMore(false);
   }
 
-  function epochDayToDate(epoch: number): string {
-    return new Date(epoch * 86400000).toISOString().split('T')[0];
-  }
-
   function formatMinutes(min: number | null | undefined): string {
     if (!min) return '—';
     const h = Math.floor(min / 60);
@@ -661,7 +656,7 @@ export default function CoachPage() {
               return (
                 <details key={s.date} className="bg-zinc-900 border border-zinc-800 rounded">
                   <summary className="px-4 py-2 cursor-pointer text-sm text-gray-300 hover:text-white flex justify-between">
-                    <span>{epochDayToDate(s.date)}</span>
+                    <span>{epoch_day_to_date_str(s.date)}</span>
                     <span className="text-gray-500">{s.conversation_turns} turn{s.conversation_turns !== 1 ? 's' : ''}</span>
                   </summary>
                   <div className="px-4 pb-3 space-y-2">

--- a/src/lib/coaching/__tests__/day.test.ts
+++ b/src/lib/coaching/__tests__/day.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { mt_date_str, mt_epoch_day, epoch_day_to_date_str } from '../day';
+
+const DAY_MS = 86400000;
+const utc_epoch_day = (d: Date) => Math.floor(d.getTime() / DAY_MS);
+
+describe('Mountain Time day boundary', () => {
+  it('keeps an MDT evening on the same Denver date after UTC rolls over', () => {
+    // 2026-07-10 01:00 UTC = 2026-07-09 19:00 MDT (UTC-6)
+    const evening = new Date('2026-07-10T01:00:00Z');
+    expect(mt_date_str(evening)).toBe('2026-07-09');
+    expect(mt_epoch_day(evening)).toBe(Date.UTC(2026, 6, 9) / DAY_MS);
+    expect(mt_epoch_day(evening)).toBe(utc_epoch_day(evening) - 1);
+  });
+
+  it('keeps an MST evening on the same Denver date after UTC rolls over', () => {
+    // 2026-01-10 02:00 UTC = 2026-01-09 19:00 MST (UTC-7)
+    const evening = new Date('2026-01-10T02:00:00Z');
+    expect(mt_date_str(evening)).toBe('2026-01-09');
+    expect(mt_epoch_day(evening)).toBe(Date.UTC(2026, 0, 9) / DAY_MS);
+  });
+
+  it('agrees with the UTC epoch day during Denver daytime', () => {
+    // 2026-07-09 15:00 UTC = 09:00 MDT — both schemes say July 9
+    const morning = new Date('2026-07-09T15:00:00Z');
+    expect(mt_epoch_day(morning)).toBe(utc_epoch_day(morning));
+    expect(mt_date_str(morning)).toBe('2026-07-09');
+  });
+
+  it('round-trips epoch day to date string', () => {
+    const evening = new Date('2026-07-10T01:00:00Z');
+    expect(epoch_day_to_date_str(mt_epoch_day(evening))).toBe('2026-07-09');
+    expect(epoch_day_to_date_str(mt_epoch_day(evening) - 1)).toBe('2026-07-08');
+  });
+});

--- a/src/lib/coaching/data-injection.ts
+++ b/src/lib/coaching/data-injection.ts
@@ -121,7 +121,7 @@ function compute_recovery_status(
 /**
  * Build the data injection string for a coaching session.
  * date_str: YYYY-MM-DD format
- * epoch_day: Math.floor(Date.now() / 86400000) for trend_cache lookup
+ * epoch_day: mt_epoch_day() (Mountain Time day boundary) for trend_cache lookup
  */
 export async function build_data_injection(
   date_str: string,

--- a/src/lib/coaching/day.ts
+++ b/src/lib/coaching/day.ts
@@ -1,0 +1,26 @@
+/**
+ * Day-boundary helpers for coaching data.
+ * Coaching tables key rows by an integer "epoch day", and the day boundary
+ * is Mountain Time (America/Denver), not UTC — a session saved at 11pm in
+ * Denver belongs to that Denver date even though UTC has rolled over.
+ * Safe on both client and server (Vercel runs UTC).
+ */
+
+const MT_TIMEZONE = 'America/Denver';
+const DAY_MS = 86400000;
+
+/** YYYY-MM-DD for the current date in Mountain Time */
+export function mt_date_str(now: Date = new Date()): string {
+  return now.toLocaleDateString('en-CA', { timeZone: MT_TIMEZONE });
+}
+
+/** Days since Unix epoch of the current Mountain Time calendar date */
+export function mt_epoch_day(now: Date = new Date()): number {
+  const [y, m, d] = mt_date_str(now).split('-').map(Number);
+  return Math.floor(Date.UTC(y, m - 1, d) / DAY_MS);
+}
+
+/** Convert a stored epoch day back to its YYYY-MM-DD calendar date */
+export function epoch_day_to_date_str(epoch_day: number): string {
+  return new Date(epoch_day * DAY_MS).toISOString().split('T')[0];
+}

--- a/src/lib/coaching/db.ts
+++ b/src/lib/coaching/db.ts
@@ -198,7 +198,7 @@ export async function save_coaching_session(session: {
 
 /**
  * Populate daily_metrics from wellness_cache (Oura) + coros_data (COROS) + optional manual inputs.
- * date_str: YYYY-MM-DD, epoch_day: Math.floor(Date.now() / 86400000)
+ * date_str: YYYY-MM-DD, epoch_day: mt_epoch_day() (Mountain Time day boundary)
  */
 export interface InjectMetrics {
   readiness?: number | null;


### PR DESCRIPTION
Cleanup of work left hanging off main after this morning's agent sessions.

## Changes
- **Mountain Time day boundary for coaching** (recovered from the cut-off agent's branch `claude/coaches-completed-session-display-yafndm`, commit dec8c32). UTC-based epoch days were rolling coach sessions/metrics into the next day during Denver evenings (6pm-midnight MT). Adds `src/lib/coaching/day.ts` + 4 unit tests.
- **CLAUDE.md**: document that Vercel access is via the `vercel` CLI and warn off the broken Vercel MCP plugin OAuth. This note lived only in Della's working tree, never committed; making it durable so future agents don't rediscover the broken MCP on quota.

## Validation
- `npx vitest run src/lib/coaching/__tests__/day.test.ts` — 4/4 pass
- `npm run lint` — clean
- Vercel preview build validates full build

## What to test
- Coach page in a Denver evening (after 6pm MT): today's session/metrics stay on the current day, don't roll to tomorrow.