### PR TITLE
Fix COROS 401s: accept legacy GUEST_PIN like every other pin-checked route

### DIFF
--- a/src/app/api/coros/data/route.ts
+++ b/src/app/api/coros/data/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
   const token = await getToken({ req: request })
   if (!token) {
     const pin = request.headers.get('X-Guest-Pin')
-    const valid_pins = (process.env.GUEST_PINS || '').split(',').map(p => p.trim()).filter(Boolean)
+    const valid_pins = (process.env.GUEST_PINS || process.env.GUEST_PIN || '').split(',').map(p => p.trim()).filter(Boolean)
     if (!pin || !valid_pins.includes(pin)) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401, headers: cors_headers(request.headers.get('origin')) })
     }

--- a/src/app/api/coros/save/route.ts
+++ b/src/app/api/coros/save/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
   const token = await getToken({ req: request })
   if (!token) {
     const pin = request.headers.get('X-Guest-Pin')
-    const valid_pins = (process.env.GUEST_PINS || '').split(',').map(p => p.trim()).filter(Boolean)
+    const valid_pins = (process.env.GUEST_PINS || process.env.GUEST_PIN || '').split(',').map(p => p.trim()).filter(Boolean)
     if (!pin || !valid_pins.includes(pin)) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401, headers: cors_headers(request.headers.get('origin')) })
     }


### PR DESCRIPTION
## Why
The COROS page shows "No data for this date" because the browser-plugin scraper gets **401** from `POST /api/coros/save`. Both coros routes read only `GUEST_PINS`, but production Vercel only has the legacy `GUEST_PIN` (singular) — so the valid-pin list was always empty. Every other pin-checked route (`/api/health`, `/api/oura/*`, `/api/strava/*`, …) already falls back to `GUEST_PIN`; the two coros routes were the only ones missing it.

Verified: the same pin returns 400 (auth passed) on `POST /api/health` and 401 on the coros routes in production.

## What to test
After the preview/production deploy:
1. `curl -X POST https://8i11.vercel.app/api/coros/save -H 'Content-Type: application/json' -H 'X-Guest-Pin: <pin>' -d '{"date":"2026-07-09","data":{"test":true}}'` → expect `{"ok":true,...}`
2. Re-run the browser-plugin COROS scrape → save should succeed
3. https://8i11.vercel.app/health/coros should populate once real data is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)