### PR TITLE
COROS page: fall back to alt report/status field names

### DIFF
--- a/src/app/health/coros/page.tsx
+++ b/src/app/health/coros/page.tsx
@@ -164,12 +164,19 @@ export default function CorosPage() {
     }
   }
 
-  const training_status = row ? (row.data as any)?.dashboard?.training_status?.status ?? '—' : null
-  const recovery_pct = row ? (row.data as any)?.dashboard?.recovery?.percentage ?? null : null
-  const recovery_status = row ? (row.data as any)?.dashboard?.recovery?.status ?? null : null
+  const training_status = row
+    ? (row.data as any)?.dashboard?.training_status?.status ?? (row.data as any)?.data?.training_status_dashboard?.status ?? '—'
+    : null
+  const recovery_pct = row
+    ? (row.data as any)?.dashboard?.recovery?.percentage ?? (row.data as any)?.data?.recovery?.percent ?? null
+    : null
+  const recovery_status = row
+    ? (row.data as any)?.dashboard?.recovery?.status ?? (row.data as any)?.data?.recovery?.status ?? null
+    : null
   const recovery_str = recovery_pct != null || recovery_status != null
     ? `${recovery_pct != null ? recovery_pct + '%' : '—'} — ${recovery_status ?? '—'}`
     : '—'
+  const report_markdown = row ? (row.data as any)?.report_markdown ?? (row.data as any)?.markdown : null
 
   return (
     <div className="min-h-screen bg-[#1a1a2e] text-gray-200 p-4">
@@ -212,19 +219,19 @@ export default function CorosPage() {
 
 
             {/* Report Markdown */}
-            {(row.data as any).report_markdown && (
+            {report_markdown && (
               <details className="mb-3 bg-[#0f0f1a] border border-white/10 rounded">
                 <summary className="cursor-pointer flex justify-between items-center px-3 py-2 text-sm text-cyan-400">
                   <span>Report Markdown</span>
                   <button
-                    onClick={copy_section('report', (row.data as any).report_markdown)}
+                    onClick={copy_section('report', report_markdown)}
                     className="text-xs text-cyan-400 hover:text-cyan-300 px-2 py-1 border border-white/10 rounded"
                   >
                     {copiedSection === 'report' ? 'Copied!' : 'Copy'}
                   </button>
                 </summary>
                 <pre className="text-xs text-gray-300 p-3 overflow-x-auto whitespace-pre-wrap">
-                  {(row.data as any).report_markdown}
+                  {report_markdown}
                 </pre>
               </details>
             )}


### PR DESCRIPTION
## Why
Yesterday's manual-input save for 2026-07-20 used a JSON shape (`data.markdown`, `data.data.training_status_dashboard.status`, `data.data.recovery.percent`) that doesn't match what the page's display logic expects (`data.report_markdown`, `data.dashboard.training_status.status`, `data.dashboard.recovery.percentage`) — the row saved fine but the Report Markdown panel and status bar stayed blank.

## What
- `training_status` / `recovery_pct` / `recovery_status` now fall back to `data.data.training_status_dashboard.status` / `data.data.recovery.percent` / `data.data.recovery.status` when the `dashboard.*` shape isn't present.
- Report Markdown panel now falls back to `data.markdown` when `data.report_markdown` isn't present.

## Test
- [ ] `/health/coros?date=2026-07-20` (already-saved row) now shows Training Status, Recovery, and the Report Markdown panel instead of blank dashes.
- Build/lint verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)