### PR TITLE
Persist in-progress coach chat session across page refresh

### DIFF
--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -476,11 +476,6 @@ export default function CoachPage() {
           const data = await res.json();
           if (data.session) {
             setTodaySession(data.session);
-            // A finalized session already exists server-side — clear any local
-            // draft (and correct for it having already been restored on mount).
-            try { sessionStorage.removeItem(`coach_session_${dateStr}`); } catch { /* unavailable — skip */ }
-            setSessionStarted(false);
-            setMessages([]);
           }
         }
       } catch { /* best effort — form shows as usual */ }

--- a/src/app/coach/page.tsx
+++ b/src/app/coach/page.tsx
@@ -253,6 +253,30 @@ export default function CoachPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Restore an in-progress chat session from sessionStorage. Runs unconditionally
+  // on mount — a local read, independent of the loadTodaySession network call —
+  // so a slow/failed fetch never blocks recovering the conversation. If today's
+  // session turns out to already be finalized server-side, loadTodaySession
+  // corrects for it afterward (see below).
+  useEffect(() => {
+    const session_key = `coach_session_${dateStr}`;
+    try {
+      const raw = sessionStorage.getItem(session_key);
+      if (raw) {
+        const draft = JSON.parse(raw);
+        if (Array.isArray(draft.messages) && draft.messages.length > 0) {
+          setMessages(draft.messages);
+          setSessionStarted(Boolean(draft.sessionStarted));
+          setMetricsCollapsed(Boolean(draft.sessionStarted));
+          if (typeof draft.dataInjection === 'string') setDataInjection(draft.dataInjection);
+          if (typeof draft.turnCount === 'number') setTurnCount(draft.turnCount);
+          if (typeof draft.totalTokens === 'number') setTotalTokens(draft.totalTokens);
+        }
+      }
+    } catch { /* corrupt draft — ignore */ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Auto-save manual-input draft as it changes
   useEffect(() => {
     const draft_key = `coach_manual_inputs_${dateStr}`;
@@ -261,6 +285,16 @@ export default function CoachPage() {
     } catch { /* storage full or unavailable — skip */ }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [weight, backPain, bowel, injuries]);
+
+  // Auto-save the in-progress chat session as it changes
+  useEffect(() => {
+    if (!sessionStarted || finalized) return;
+    const session_key = `coach_session_${dateStr}`;
+    try {
+      sessionStorage.setItem(session_key, JSON.stringify({ messages, sessionStarted, dataInjection, turnCount, totalTokens }));
+    } catch { /* storage full or unavailable — skip */ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, sessionStarted, dataInjection, turnCount, totalTokens, finalized]);
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -440,7 +474,14 @@ export default function CoachPage() {
         const res = await fetch(`/api/coaching/today?date=${epochDay}`);
         if (res.ok) {
           const data = await res.json();
-          if (data.session) setTodaySession(data.session);
+          if (data.session) {
+            setTodaySession(data.session);
+            // A finalized session already exists server-side — clear any local
+            // draft (and correct for it having already been restored on mount).
+            try { sessionStorage.removeItem(`coach_session_${dateStr}`); } catch { /* unavailable — skip */ }
+            setSessionStarted(false);
+            setMessages([]);
+          }
         }
       } catch { /* best effort — form shows as usual */ }
       setTodayChecked(true);
@@ -614,7 +655,10 @@ export default function CoachPage() {
       const data = await res.json();
       setFinalized(true);
       setSavedSummary(data.summary || '');
-      try { sessionStorage.removeItem(`coach_manual_inputs_${dateStr}`); } catch { /* unavailable — skip */ }
+      try {
+        sessionStorage.removeItem(`coach_manual_inputs_${dateStr}`);
+        sessionStorage.removeItem(`coach_session_${dateStr}`);
+      } catch { /* unavailable — skip */ }
       // Mirror what finalize stored so a re-render shows the completed view
       setTodaySession({
         date: epochDay,


### PR DESCRIPTION
## Summary
- Second half of #245 — manual-input persistence already shipped in #261; this restores the in-progress conversation across a refresh too.
- Same per-day `sessionStorage` pattern as the manual inputs, key `coach_session_${dateStr}`.
- Restore-on-mount is independent of the `loadTodaySession` network call (doesn't wait on/depend on the fetch succeeding), so a flaky connection doesn't block recovering the draft — the fetch instead corrects for a stale draft afterward if it finds a session already finalized server-side.
- Cleared on Save & Finalize alongside the existing manual-inputs key.

Closes #245

## Test plan
- [ ] Start a coach session, send a follow-up, hard-refresh mid-conversation → chat, turn count, tokens, and collapsed metrics restore
- [ ] Refresh while offline/slow network → draft still restores (doesn't depend on the today-session fetch)
- [ ] Save & Finalize → both storage keys clear; next refresh shows the finalized view, not a stale draft
- [ ] `npm run build` && `npm run lint` clean (done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)