### PR TITLE
Document that this VM is not a dev environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,17 @@
 | AI | @anthropic-ai/sdk |
 | Testing | vitest |
 
+## Environment Note
+
+This machine is a VM, **not** a dev environment. The app deploys via Vercel (pushes to `main` auto-deploy; PRs get previews) — nothing app-runtime needs to run locally. Do not start a local server to verify changes unless explicitly asked; use the Vercel preview instead. Local commands are only for the pre-PR gate: `npm run build`, `npm run lint`, `npx vitest`.
+
 ## Development Commands
 ```bash
-npm run dev      # Start dev server on :3000
-npm run build    # Build for production
-npm run lint     # ESLint
+npm run build    # Build for production (pre-PR gate)
+npm run lint     # ESLint (pre-PR gate)
 npx vitest       # Run tests (src/lib/f1/__tests__/)
+npm start        # Local server on :3000 if ever needed (after build)
+                 # Avoid `npm run dev` on this VM — Fast Refresh reload loop
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# 8i11 — onthisday
 
-## Getting Started
+Personal Next.js app: On This Day stories, text tools, health dashboards (Oura / Ride with GPS / COROS), F1 predictions, games, and weather.
 
-First, run the development server:
+**Live:** https://8i11.vercel.app
+
+## Deployment
+
+This app deploys via **Vercel** — pushes to `main` go live automatically, and PRs get preview deployments. No local server is needed for normal development; the development VM is not a runtime environment.
+
+## Local verification (pre-PR gate)
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run build    # Must pass before opening a PR
+npm run lint     # Must pass before opening a PR
+npx vitest       # Run tests
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+If you ever need a local server, use `npm run build && npm start`. Avoid `npm run dev` on the development VM — it thrashes in a Fast Refresh reload loop there (Turbopack-in-sandbox quirk).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+See `CLAUDE.md` for the full tech stack, project structure, and workflow.


### PR DESCRIPTION
Closes #237.

Docs-only change, no code touched:

- **CLAUDE.md** — new "Environment Note" section (VM is not a dev env; Vercel deploys; local commands are only the pre-PR gate). Development Commands drops `npm run dev`, documents `npm start` as the fallback with the Fast Refresh-loop warning. Pre-PR build/lint gate is kept.
- **README.md** — stock create-next-app boilerplate replaced with a short project README (live URL, Vercel deployment, gate commands).

**What to test:** read the two files. No runtime behavior changes; a Haiku sweep confirmed no other docs/hooks reference starting a local server (the `localhost:3000` CORS origins in three API routes are intentional and untouched).

**Expected:** Vercel preview builds green; site unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)