### PR TITLE
Generate unique, non-formulaic Substack titles with history-based dedupe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Per `src/proxy.ts`:
 - API: `/api/auth/*`, `/api/health`, `/api/stories`, `/api/prompts`, `/api/oura/*`
 
 ## Database Schema
-**Main DB:** `posts`, `archive_info`, `stories`, `story_audits`, `mr_bear_rookies`
+**Main DB:** `posts`, `archive_info`, `stories`, `story_audits`, `mr_bear_rookies`, `substack_titles`
 **F1 DB:** `f1_seasons`, `f1_sessions`, `f1_drivers`, `f1_predictions`, `f1_scores`, `f1_player_state`, `f1_cancelled_rounds`
 
 Both DBs use same Turso connection in production, same `data/posts.db` locally.
@@ -158,6 +158,8 @@ All model IDs are centralised in `src/lib/models.ts`. Import `MODELS` from there
 **F1 / Mr. Bear:** Pure TypeScript, no LLM. Rankings from last 3 race weekends qualifying averaged. Rookies via `mr_bear_rookies` DB table.
 
 **Story generation:** Claude with ephemeral prompt caching. Every source post linked exactly once. ~$0.17/story with Opus.
+
+**Substack titles:** `/api/clean-text` mode `substack` returns a headline title/subtitle plus six alternates. Anti-formula logic lives in `src/lib/substack_titles.ts` (pure, tested): a banned-template list of overdone title shapes, near-duplicate detection (≥60% content-word overlap), output parsing, and rotating "angles" injected per request for variety. Titles are deduped against both `substack_titles` (everything the tool has offered, including unpicked alternates) and the `posts` archive (real published titles). Offending titles trigger one corrective retry that keeps the narrative intact. All history reads/writes are best-effort — a DB failure degrades to a normal generation rather than losing the story. Note: because unpicked alternates are recorded, regenerating the same story cannot return a title from a previous run.
 
 **Uploads:** 4.5MB Vercel limit. Client batches posts (500/req) and HTML (50/req).
 

--- a/src/app/api/clean-text/route.ts
+++ b/src/app/api/clean-text/route.ts
@@ -7,6 +7,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODELS } from '@/lib/models';
+import {
+  all_offered_pairs,
+  CLICHE_PATTERNS,
+  find_title_problems,
+  parse_substack_output,
+  pick_title_angles,
+  TitlePair,
+} from '@/lib/substack_titles';
+import { get_generated_titles, get_published_titles, record_generated_titles } from '@/lib/db';
 
 // Substack generation with vision can run long; Vercel Pro allows up to 300s.
 export const maxDuration = 300;
@@ -58,6 +67,28 @@ export async function POST(request: NextRequest) {
       }
 
       const client = new Anthropic({ apiKey: api_key });
+
+      // Title history: published Substack posts + everything this tool has
+      // previously offered. Best-effort — a DB hiccup must not block a story.
+      let used_titles: TitlePair[] = [];
+      try {
+        const [published, generated] = await Promise.all([
+          get_published_titles(150),
+          get_generated_titles(150),
+        ]);
+        used_titles = [...generated, ...published];
+      } catch (e) {
+        console.error('Title history lookup failed:', e instanceof Error ? e.message : String(e));
+      }
+
+      const previous_titles = used_titles.map(t => t.title);
+      const angles = pick_title_angles(3);
+
+      const used_titles_block = used_titles.length > 0
+        ? used_titles.slice(0, 200).map(t => `- ${t.title}`).join('\n')
+        : '(none yet)';
+
+      const banned_templates_block = CLICHE_PATTERNS.map(p => `- ${p.name}`).join('\n');
 
       const prompt_text = `You will be acting as a creative story generator that helps users transform their experiences into engaging Substack narratives.
 
@@ -111,12 +142,42 @@ Write for friends, family, and outdoor enthusiasts. The story should feel like s
 **Ending:**
 Always conclude with a reflective, meaningful takeaway that conveys appreciation or gratitude in a subtle, grounded way. The closing thought should feel original and lived-in, not like a slogan or aphorism. Avoid formulaic wisdom, inspirational clichEs, or stock structures. Aim for a quiet insight that deepens the moment rather than summarizing it. Avoid cliche words like "maybe".
 
+## Titles and Subtitles
+
+This is the part that matters most, and the part most often done badly. Read these rules carefully.
+
+**The title** (2 to 7 words):
+- It must come out of THIS story's specific details. If the title could sit on top of somebody else's post about a different day, it is wrong.
+- Funny is good. Quirky is good. Dry is good. Generic wistfulness is not.
+- Use the actual nouns from the story, the odd ones especially: the equipment, the place names, the animals, the errands, the rule the author made up.
+- No colons. No "A Story of". No rhyming. No alliteration for its own sake.
+
+**Banned title templates.** These are worn out. Do not produce a title that fits any of these shapes, in any wording:
+${banned_templates_block}
+
+Also avoid anything that merely rhymes with those shapes, e.g. "Something Something, Again and Again", "When the Wind Had Other Plans", "The Quiet Art of Waiting". If a title feels like it came pre-made off a shelf, throw it out and write another.
+
+**Titles already used.** Every title below has been used before. Do not repeat any of them and do not produce a near-reword of one:
+${used_titles_block}
+
+**Angles to try for this post.** Push at least a couple of your options through these specific approaches:
+${angles.map(a => `- ${a}`).join('\n')}
+
+**The subtitle** (10 to 25 words, one sentence, no period required):
+- This is NOT a second punchline. It is the deck: it tells the reader what the post actually contains, in a wry, slightly deadpan voice.
+- Concrete and specific. Listing the real things that happened is good, especially when the list is absurd on its own.
+- Examples of the right shape and length:
+  - "Blood draws, physical therapy, wasps, brake repairs, and the surprisingly exhausting act of doing the right thing."
+  - "A masterclass in how an entire day can disappear without turning a single pedal."
+  - "Featuring a vampire, a physical therapist, angry wasps, hydraulic brakes, and exactly zero mountain biking."
+- Do not use those examples. They show the register and length only.
+
 **Required Output Format:**
 
 Present your story using the following exact format:
 
-Title: [Write a 2-5 word title that is witty and sparks curiosity]
-Sub Title: [Write a 2-5 word subtitle that is funny or ironic]
+Title: [The strongest title, per the rules above]
+Sub Title: [The matching subtitle, per the rules above]
 
 [Write the complete narrative here following all guidelines above. Do not use any tags.]
 
@@ -124,7 +185,17 @@ captions
 
 [If images were provided, create a bulleted list of short witty captions for each image. Format as "Image 1: [Caption]", "Image 2: [Caption]"]
 
-[If no images were provided, write "No images provided."]`;
+[If no images were provided, write "No images provided."]
+
+alternate titles
+
+[Six more title and subtitle pairs, each genuinely different from the headline pair and from each other, not six rewordings of one idea. Range from dry to absurd. Follow every title and subtitle rule above. Format each on one line, exactly like this:]
+1. Title: [title] | Sub Title: [subtitle]
+2. Title: [title] | Sub Title: [subtitle]
+3. Title: [title] | Sub Title: [subtitle]
+4. Title: [title] | Sub Title: [subtitle]
+5. Title: [title] | Sub Title: [subtitle]
+6. Title: [title] | Sub Title: [subtitle]`;
 
       const content_blocks: Anthropic.MessageParam['content'] = [];
 
@@ -143,16 +214,65 @@ captions
 
       content_blocks.push({ type: 'text', text: prompt_text });
 
-      const substack_result = await client.messages.create({
+      const messages: Anthropic.MessageParam[] = [{ role: 'user', content: content_blocks }];
+
+      const run_substack = (msgs: Anthropic.MessageParam[]) => client.messages.create({
         model: MODELS.SUBSTACK,
         max_tokens: 10000,
         thinking: { type: 'disabled' },
-        messages: [{ role: 'user', content: content_blocks }],
+        messages: msgs,
       });
 
-      const substack_raw = substack_result.content[0].type === 'text'
-        ? substack_result.content[0].text.trim()
-        : '';
+      const text_of = (result: Anthropic.Message) =>
+        result.content[0]?.type === 'text' ? result.content[0].text.trim() : '';
+
+      const first = await run_substack(messages);
+      let substack_raw = text_of(first);
+      let input_tokens = first.usage.input_tokens;
+      let output_tokens = first.usage.output_tokens;
+
+      let parsed = parse_substack_output(substack_raw);
+      const problems = find_title_problems(parsed, previous_titles);
+
+      // One corrective pass when the model reaches for a worn-out template or
+      // repeats a title. Narrative stays put; only the titles get rewritten.
+      if (problems.length > 0 && substack_raw) {
+        const retry_instruction = `These titles do not pass:
+
+${problems.map(p => `- "${p.title}" ${p.reason}`).join('\n')}
+
+Output the post again, byte for byte identical in the narrative and the captions, but replace every title and subtitle listed above with a new one. Keep the same output format. The replacements must not fit any banned template, must not repeat or reword any already-used title, and must be built from the specific details of this story.`;
+
+        try {
+          const second = await run_substack([
+            ...messages,
+            { role: 'assistant', content: substack_raw },
+            { role: 'user', content: retry_instruction },
+          ]);
+          const retry_raw = text_of(second);
+          input_tokens += second.usage.input_tokens;
+          output_tokens += second.usage.output_tokens;
+
+          const retry_parsed = parse_substack_output(retry_raw);
+          // Only take the retry if it is actually cleaner than the first pass.
+          if (
+            retry_parsed.title &&
+            find_title_problems(retry_parsed, previous_titles).length < problems.length
+          ) {
+            substack_raw = retry_raw;
+            parsed = retry_parsed;
+          }
+        } catch (e) {
+          console.error('Substack title retry failed:', e instanceof Error ? e.message : String(e));
+        }
+      }
+
+      try {
+        await record_generated_titles(all_offered_pairs(parsed));
+      } catch (e) {
+        console.error('Title history write failed:', e instanceof Error ? e.message : String(e));
+      }
+
       const substack_text = substack_raw
         .replace(/\s*—\s*/g, ', ')
         .replace(/\s*–\s*/g, ', ');
@@ -160,10 +280,7 @@ captions
       return NextResponse.json({
         success: true,
         substack: substack_text,
-        usage: {
-          input_tokens: substack_result.usage.input_tokens,
-          output_tokens: substack_result.usage.output_tokens,
-        },
+        usage: { input_tokens, output_tokens },
       });
     }
 

--- a/src/lib/__tests__/substack_titles.test.ts
+++ b/src/lib/__tests__/substack_titles.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  all_offered_pairs,
+  find_cliche_pattern,
+  find_title_problems,
+  is_duplicate_title,
+  normalize_title,
+  parse_substack_output,
+  pick_title_angles,
+  TITLE_ANGLES,
+} from '../substack_titles';
+
+describe('normalize_title', () => {
+  it('lowercases, strips punctuation and collapses whitespace', () => {
+    expect(normalize_title('  The Wind,   Again!  ')).toBe('the wind again');
+  });
+
+  it('normalizes curly quotes', () => {
+    expect(normalize_title('Mo’s Brakes')).toBe("mo's brakes");
+  });
+});
+
+describe('find_cliche_pattern', () => {
+  const overdone = [
+    'Into the Wind Again',
+    'When Your Bike Has Other Ideas',
+    'The Art of Doing Nothing',
+    'A Love Letter to Missoula',
+    'In Praise of Slow Mornings',
+    'Notes From the Garage',
+    'Confessions of a Weekend Mechanic',
+    'Adventures in Wasp Control',
+    'The Trouble With Brake Fluid',
+    'Tales From the Trailhead',
+    'Lessons From a Blood Draw',
+    'A Brief History of My Excuses',
+    'Chasing Daylight',
+    'That Time I Skipped the Ride',
+    'How I Learned to Wait',
+    'On Wasps and Waiting',
+    'Trail Day Gone Wrong',
+    'The Missoula Chronicles',
+    'Welcome to the Garage',
+    'Everything I Know About Brakes',
+    'Brake Fluid: A Love Story',
+    'In Which Nothing Happens',
+    'The Day I Stayed Home',
+    'Anatomy of a Rest Day',
+    'Ode to Hydraulic Fluid',
+    'Wasp Control 101',
+    'The Ride, Revisited',
+    'Small Things That Count',
+  ];
+
+  it.each(overdone)('rejects %s', title => {
+    expect(find_cliche_pattern(title)).not.toBeNull();
+  });
+
+  const fine = [
+    'Outridden by Adulting',
+    'Brake Fluid Before Bike Fluid',
+    'My Biggest Ride Was to the Bike Shop',
+    'Medic Earth vs the Property Line',
+    'Two Garage Reorganizations, Zero Miles',
+  ];
+
+  it.each(fine)('accepts %s', title => {
+    expect(find_cliche_pattern(title)).toBeNull();
+  });
+
+  it('returns null for an empty title', () => {
+    expect(find_cliche_pattern('   ')).toBeNull();
+  });
+});
+
+describe('is_duplicate_title', () => {
+  const previous = ['Outridden by Adulting', 'Brake Fluid Before Bike Fluid'];
+
+  it('catches an exact repeat regardless of case and punctuation', () => {
+    expect(is_duplicate_title('outridden by adulting!', previous)).toBe(true);
+  });
+
+  it('catches a near reword', () => {
+    expect(is_duplicate_title('Outridden by the Adulting', previous)).toBe(true);
+  });
+
+  it('allows a genuinely different title', () => {
+    expect(is_duplicate_title('Two Garage Reorganizations, Zero Miles', previous)).toBe(false);
+  });
+
+  it('does not flag titles that only share stopwords', () => {
+    expect(is_duplicate_title('A Yard of My Own', ['The Ride to the Shop'])).toBe(false);
+  });
+
+  it('handles an empty history', () => {
+    expect(is_duplicate_title('Anything At All', [])).toBe(false);
+  });
+});
+
+const SAMPLE = `Title: Outridden by Adulting
+Sub Title: Blood draws, physical therapy, wasps, and one stubborn rule about other people's brakes
+
+I didn't get in the rides I needed. Yesterday started reasonably enough.
+
+captions
+
+Image 1: The wasp situation, ongoing
+
+alternate titles
+
+1. Title: Brake Fluid Before Bike Fluid | Sub Title: Why the trail had to wait until my partner's bike was whole again
+2. Title: Two Garage Reorganizations, Zero Miles | Sub Title: An accounting of everything that happened instead of riding
+`;
+
+describe('parse_substack_output', () => {
+  it('pulls the headline pair and the alternates', () => {
+    const parsed = parse_substack_output(SAMPLE);
+    expect(parsed.title).toBe('Outridden by Adulting');
+    expect(parsed.subtitle).toContain('Blood draws');
+    expect(parsed.alternates).toHaveLength(2);
+    expect(parsed.alternates[1].title).toBe('Two Garage Reorganizations, Zero Miles');
+    expect(parsed.alternates[1].subtitle).toBe('An accounting of everything that happened instead of riding');
+  });
+
+  it('does not mistake narrative text for a title line', () => {
+    const parsed = parse_substack_output('Title: Real One\nSub Title: Real deck\n\nTitle: not this one');
+    expect(parsed.title).toBe('Real One');
+    expect(parsed.alternates).toHaveLength(0);
+  });
+
+  it('tolerates "Subtitle" spelled without the space', () => {
+    const parsed = parse_substack_output('Title: A\nSubtitle: B');
+    expect(parsed.subtitle).toBe('B');
+  });
+
+  it('returns empties for unparseable output', () => {
+    const parsed = parse_substack_output('just some prose');
+    expect(parsed.title).toBe('');
+    expect(parsed.alternates).toEqual([]);
+  });
+
+  it('collects every offered pair', () => {
+    expect(all_offered_pairs(parse_substack_output(SAMPLE))).toHaveLength(3);
+  });
+});
+
+describe('find_title_problems', () => {
+  it('is clean when nothing is overdone or repeated', () => {
+    expect(find_title_problems(parse_substack_output(SAMPLE), ['Something Else Entirely'])).toEqual([]);
+  });
+
+  it('flags a cliche template', () => {
+    const parsed = parse_substack_output('Title: Into the Wind Again\nSub Title: A deck');
+    const problems = find_title_problems(parsed, []);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].reason).toContain('overdone');
+  });
+
+  it('flags a repeat of a previously used title', () => {
+    const problems = find_title_problems(parse_substack_output(SAMPLE), ['Outridden by Adulting']);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].title).toBe('Outridden by Adulting');
+    expect(problems[0].reason).toContain('previous post');
+  });
+
+  it('flags an alternate that rewords the headline', () => {
+    const parsed = parse_substack_output(
+      'Title: Outridden by Adulting\nSub Title: A deck\n\nalternate titles\n\n1. Title: Outridden by the Adulting | Sub Title: Another deck'
+    );
+    const problems = find_title_problems(parsed, []);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].reason).toContain('same batch');
+  });
+});
+
+describe('pick_title_angles', () => {
+  it('returns the requested count with no repeats', () => {
+    const picked = pick_title_angles(3);
+    expect(picked).toHaveLength(3);
+    expect(new Set(picked).size).toBe(3);
+    for (const angle of picked) expect(TITLE_ANGLES).toContain(angle);
+  });
+
+  it('caps at the pool size', () => {
+    expect(pick_title_angles(999)).toHaveLength(TITLE_ANGLES.length);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import { createClient, Client } from '@libsql/client';
 import { StoryAudit } from '@/lib/story_audit';
+import { normalize_title, TitlePair } from '@/lib/substack_titles';
 
 // Detect if we're using Turso (production) or SQLite (local)
 const is_turso = !!process.env.TURSO_DATABASE_URL;
@@ -137,6 +138,22 @@ async function init_schema(): Promise<void> {
       content TEXT NOT NULL,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     )
+  `);
+
+  // Every title/subtitle the Substack generator has offered, so it never
+  // repeats itself across generations.
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS substack_titles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      subtitle TEXT,
+      title_norm TEXT NOT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await db.execute(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_substack_titles_norm ON substack_titles(title_norm)
   `);
 
   // Coaching tables
@@ -1844,6 +1861,66 @@ export async function delete_text_note(id: string): Promise<boolean> {
     args: [id]
   });
   return result.rowsAffected > 0;
+}
+
+// ============================================================================
+// Substack title history (Say What? → Substack Post)
+// ============================================================================
+
+/**
+ * Titles already published to Substack, newest first. The `posts` table is the
+ * Substack archive import, so these are the real used-title history.
+ */
+export async function get_published_titles(limit: number = 200): Promise<TitlePair[]> {
+  await ensure_schema();
+  const db = get_client();
+
+  const result = await db.execute({
+    sql: 'SELECT title, subtitle FROM posts ORDER BY local_date DESC LIMIT ?',
+    args: [limit]
+  });
+
+  return result.rows.map(row => ({
+    title: (row.title as string) || '',
+    subtitle: (row.subtitle as string) || ''
+  })).filter(p => p.title);
+}
+
+/** Titles the generator has previously offered, newest first. */
+export async function get_generated_titles(limit: number = 200): Promise<TitlePair[]> {
+  await ensure_schema();
+  const db = get_client();
+
+  const result = await db.execute({
+    sql: 'SELECT title, subtitle FROM substack_titles ORDER BY id DESC LIMIT ?',
+    args: [limit]
+  });
+
+  return result.rows.map(row => ({
+    title: (row.title as string) || '',
+    subtitle: (row.subtitle as string) || ''
+  })).filter(p => p.title);
+}
+
+/** Record offered titles. Duplicates are ignored via the unique norm index. */
+export async function record_generated_titles(pairs: TitlePair[]): Promise<void> {
+  if (pairs.length === 0) return;
+  await ensure_schema();
+  const db = get_client();
+
+  for (const pair of pairs) {
+    const norm = normalize_title(pair.title);
+    if (!norm) continue;
+    try {
+      await db.execute({
+        sql: 'INSERT OR IGNORE INTO substack_titles (title, subtitle, title_norm) VALUES (?, ?, ?)',
+        args: [pair.title, pair.subtitle || null, norm]
+      });
+    } catch (e) {
+      // Title history is best-effort — never fail a generation over it
+      console.error('record_generated_titles failed:', e instanceof Error ? e.message : String(e));
+    }
+  }
 }
 
 // ============================================================================

--- a/src/lib/substack_titles.ts
+++ b/src/lib/substack_titles.ts
@@ -1,0 +1,223 @@
+/**
+ * Substack title helpers — anti-cliche detection, duplicate detection, and
+ * output parsing for the `substack` mode of /api/clean-text.
+ *
+ * Pure functions only (no DB, no network) so they stay unit-testable.
+ */
+
+export interface TitlePair {
+  title: string;
+  subtitle: string;
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'as', 'at', 'but', 'by', 'for', 'from', 'in', 'into', 'is',
+  'it', 'its', 'my', 'of', 'on', 'or', 'the', 'this', 'to', 'up', 'with', 'your',
+]);
+
+/** Lowercase, strip punctuation and collapse whitespace for comparison. */
+export function normalize_title(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[‘’“”]/g, "'")
+    .replace(/[^a-z0-9' ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function content_words(raw: string): string[] {
+  return normalize_title(raw)
+    .split(' ')
+    .filter(w => w.length > 0 && !STOPWORDS.has(w));
+}
+
+/**
+ * Overdone title shapes. These are the "pre-made cheesy" templates — anything
+ * matching gets rejected and regenerated rather than shipped.
+ */
+export const CLICHE_PATTERNS: Array<{ name: string; test: RegExp }> = [
+  { name: '"... Again"', test: /\bagain$/ },
+  { name: '"When Your/When The ..."', test: /^when (your|the|you|i|it|a) \b/ },
+  { name: '"The Art of ..."', test: /^the (art|zen|joy|beauty|magic|power) of\b/ },
+  { name: '"A Love Letter to ..."', test: /^(a )?love letter to\b/ },
+  { name: '"In Praise of ..."', test: /^in (praise|defense|defence) of\b/ },
+  { name: '"Notes/Dispatches/Postcards from ..."', test: /^(notes|dispatches|postcards|letters|scenes|report) from\b/ },
+  { name: '"Confessions of ..."', test: /^confessions of\b/ },
+  { name: '"Adventures in ..."', test: /^adventures in\b/ },
+  { name: '"The Trouble With ..."', test: /^the (trouble|problem) with\b/ },
+  { name: '"Tales of/from ..."', test: /^tales? (of|from)\b/ },
+  { name: '"Lessons from/in ..."', test: /^lessons (from|in)\b/ },
+  { name: '"A Brief History of ..."', test: /^a (brief|short) history of\b/ },
+  { name: '"Chasing ..."', test: /^chasing\b/ },
+  { name: '"That Time I ..."', test: /^that time (i|we)\b/ },
+  { name: '"How I .../Why I ..."', test: /^(how|why) (i|we|you) \b/ },
+  { name: '"On X and Y"', test: /^on \w+ and \w+$/ },
+  { name: '"... Gone Wrong"', test: /\bgone (wrong|sideways|right)$/ },
+  { name: '"The X Chronicles/Diaries/Files"', test: /\b(chronicles|diaries|files|edition|saga)$/ },
+  { name: '"Welcome to ..."', test: /^welcome to\b/ },
+  { name: '"Everything I/You ..."', test: /^everything (i|you|we)\b/ },
+  { name: '"... : A Love Story"', test: /\ba (love )?story$/ },
+  { name: '"In Which ..."', test: /^in which\b/ },
+  { name: '"The Day I/The Day The ..."', test: /^the day (i|we|the|my)\b/ },
+  { name: '"Anatomy of ..."', test: /^anatomy of\b/ },
+  { name: '"Ode to ..."', test: /^(an )?ode to\b/ },
+  { name: '"... 101"', test: /\b101$/ },
+  { name: '"... , Revisited"', test: /\brevisited$/ },
+  { name: '"Small Things/Little Things ..."', test: /^(small|little|quiet|simple) (things|moments|joys|victories)\b/ },
+];
+
+/** Returns the name of the overdone template a title matches, or null. */
+export function find_cliche_pattern(title: string): string | null {
+  const norm = normalize_title(title);
+  if (!norm) return null;
+  for (const { name, test } of CLICHE_PATTERNS) {
+    if (test.test(norm)) return name;
+  }
+  return null;
+}
+
+/**
+ * True when `title` is the same as, or a close rewording of, a previous title.
+ * Close = identical after normalization, or >= 60% content-word overlap.
+ */
+export function is_duplicate_title(title: string, previous: string[]): boolean {
+  const norm = normalize_title(title);
+  if (!norm) return false;
+
+  const words = new Set(content_words(title));
+
+  for (const prev of previous) {
+    const prev_norm = normalize_title(prev);
+    if (!prev_norm) continue;
+    if (prev_norm === norm) return true;
+
+    const prev_words = new Set(content_words(prev));
+    if (words.size === 0 || prev_words.size === 0) continue;
+
+    let shared = 0;
+    for (const w of words) if (prev_words.has(w)) shared++;
+    const union = words.size + prev_words.size - shared;
+    if (union > 0 && shared / union >= 0.6) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Rotating title angles. A random couple are injected into each prompt so
+ * successive generations approach the title from different directions instead
+ * of settling into one house style.
+ */
+export const TITLE_ANGLES: string[] = [
+  'name a specific, concrete object from the story and let it carry the whole title',
+  'use a flat understatement that undersells what actually happened',
+  'borrow the register of an official notice, form, or incident report',
+  'lead with a number or quantity that sounds oddly precise',
+  'misapply a technical or bureaucratic term to something domestic',
+  'write it as a fragment of overheard speech',
+  'state a plain fact from the story that sounds absurd out of context',
+  'name what did NOT happen instead of what did',
+  'pair two nouns from the story that have no business together',
+  'use the vocabulary of a completely unrelated field (finance, law, geology, sports officiating)',
+  'phrase it as a self-assessment or verdict on yourself',
+  'name the day by its least impressive accomplishment',
+  'use a verb that is too dramatic for the thing it describes',
+  'title it after the rule, excuse, or superstition at the center of the story',
+  'let a piece of equipment or an animal be the subject doing the acting',
+  'use a comparison to something mundane and slightly unflattering',
+];
+
+/** Pick `count` distinct angles at random. */
+export function pick_title_angles(count: number, rand: () => number = Math.random): string[] {
+  const pool = [...TITLE_ANGLES];
+  const picked: string[] = [];
+  const n = Math.min(count, pool.length);
+  for (let i = 0; i < n; i++) {
+    const idx = Math.floor(rand() * pool.length) % pool.length;
+    picked.push(pool.splice(idx, 1)[0]);
+  }
+  return picked;
+}
+
+export interface ParsedSubstack {
+  title: string;
+  subtitle: string;
+  alternates: TitlePair[];
+}
+
+const TITLE_LINE = /^\s*title\s*:\s*(.+)$/i;
+const SUBTITLE_LINE = /^\s*sub\s*-?\s*title\s*:\s*(.+)$/i;
+const ALTERNATES_HEADER = /^\s*(alternate|alternative)\s+titles?\s*:?\s*$/i;
+/** e.g. "3. Title: Foo | Sub Title: Bar" */
+const ALTERNATE_LINE = /^\s*(?:[-*]|\d+[.)])?\s*title\s*:\s*(.+?)\s*\|\s*sub\s*-?\s*title\s*:\s*(.+?)\s*$/i;
+
+/** Pull the headline pair and the alternate options out of the model's output. */
+export function parse_substack_output(text: string): ParsedSubstack {
+  const lines = text.split('\n');
+  let title = '';
+  let subtitle = '';
+  const alternates: TitlePair[] = [];
+  let in_alternates = false;
+
+  for (const line of lines) {
+    if (ALTERNATES_HEADER.test(line)) {
+      in_alternates = true;
+      continue;
+    }
+
+    if (in_alternates) {
+      const alt = line.match(ALTERNATE_LINE);
+      if (alt) alternates.push({ title: alt[1].trim(), subtitle: alt[2].trim() });
+      continue;
+    }
+
+    if (!title) {
+      const t = line.match(TITLE_LINE);
+      if (t) { title = t[1].trim(); continue; }
+    }
+    if (!subtitle) {
+      const s = line.match(SUBTITLE_LINE);
+      if (s) subtitle = s[1].trim();
+    }
+  }
+
+  return { title, subtitle, alternates };
+}
+
+/** Every title the model offered in one generation (headline + alternates). */
+export function all_offered_pairs(parsed: ParsedSubstack): TitlePair[] {
+  const pairs: TitlePair[] = [];
+  if (parsed.title) pairs.push({ title: parsed.title, subtitle: parsed.subtitle });
+  for (const alt of parsed.alternates) {
+    if (alt.title) pairs.push(alt);
+  }
+  return pairs;
+}
+
+export interface TitleProblem {
+  title: string;
+  reason: string;
+}
+
+/**
+ * Check the headline and every alternate against the cliche templates and the
+ * used-title history. Returns one problem per offending title.
+ */
+export function find_title_problems(parsed: ParsedSubstack, previous: string[]): TitleProblem[] {
+  const problems: TitleProblem[] = [];
+  const seen_this_run: string[] = [];
+
+  for (const pair of all_offered_pairs(parsed)) {
+    const cliche = find_cliche_pattern(pair.title);
+    if (cliche) {
+      problems.push({ title: pair.title, reason: `uses the overdone ${cliche} template` });
+    } else if (is_duplicate_title(pair.title, previous)) {
+      problems.push({ title: pair.title, reason: 'repeats a title already used on a previous post' });
+    } else if (is_duplicate_title(pair.title, seen_this_run)) {
+      problems.push({ title: pair.title, reason: 'is a reword of another option in this same batch' });
+    }
+    seen_this_run.push(pair.title);
+  }
+
+  return problems;
+}


### PR DESCRIPTION
## Problem

The Substack Post generator on `/creative/text-cleaner` was producing cheesy, off-the-shelf titles ("… Again", "When Your …") and had started repeating them.

Two root causes:

1. **The prompt asked for exactly that.** The entire title spec was two lines:
   ```
   Title: [Write a 2-5 word title that is witty and sparks curiosity]
   Sub Title: [Write a 2-5 word subtitle that is funny or ironic]
   ```
   "2-5 words, witty" with no other constraint reliably produces shelf-stock phrasing. The 2-5 word subtitle in particular forces a second punchline where a descriptive deck belongs.
2. **Nothing was ever stored.** Generated titles were returned and forgotten, so the model had no way to know what it had already produced. Duplicates were inevitable.

## Changes

**`src/lib/substack_titles.ts`** (new, pure functions — no DB, no network)
- 28 overdone title templates as regexes: `… Again`, `When Your …`, `The Art of …`, `A Love Letter to …`, `Notes From …`, `Confessions of …`, `Chasing …`, `That Time I …`, `On X and Y`, `… : A Love Story`, `The X Chronicles`, and others.
- `is_duplicate_title` — exact match after normalization, or ≥60% content-word overlap (catches rewords, ignores stopwords).
- `parse_substack_output` — extracts the headline pair and the alternates from the model's output.
- 16 rotating title angles; three are picked at random per request so successive generations don't converge on one house style.

**`src/app/api/clean-text/route.ts`** (substack mode)
- Title rules rewritten: must be built from the specific nouns of this story, no colons, no rhyming, no alliteration for its own sake.
- Banned templates injected into the prompt and enforced against the output.
- Subtitle respecified as a deck: 10-25 words, one sentence, wry and concrete, listing what actually happened. This is the largest change to how output reads.
- Six alternate title/subtitle pairs now returned per generation, formatted `Title: … | Sub Title: …`.
- Used-title history injected as an explicit do-not-repeat list.
- Auto-retry: headline and all six alternates are checked against the templates, the history, and each other. Offenders trigger one corrective pass that keeps the narrative and captions identical and rewrites only the flagged titles. The retry is accepted only if measurably cleaner.
- Token usage is summed across both calls.

**`src/lib/db.ts`**
- New `substack_titles` table (unique index on the normalized title) with `record_generated_titles` / `get_generated_titles`.
- `get_published_titles` reads the `posts` archive, so the dedupe list is populated with real published titles from the first run rather than starting empty.

DB lookups, history writes, and the retry call are each wrapped so a failure logs and degrades rather than losing a generated story.

## Testing

`src/lib/__tests__/substack_titles.test.ts` — 52 tests covering normalization, all 28 cliché patterns (plus titles that must pass), duplicate and near-reword detection, output parsing including malformed input, and angle selection.

- `npx vitest` — 52 passed
- `npm run lint` — clean
- `npm run build` — passes

## What to test on the preview

`/creative/text-cleaner` → paste a story → **Substack Post**.

Expected:
- Headline title reads specific to the story, not like a template.
- Subtitle is a full descriptive sentence, not a 2-5 word quip.
- An `alternate titles` section with six more pairs, ranging dry to absurd.
- Generating twice on the same story yields different titles both times.

## Known behavior

Every title offered is recorded, including unpicked alternates. Regenerating the same story therefore cannot return a title from the previous run. That is the uniqueness guarantee working as designed, but it does mean a title you liked can't be recovered by regenerating. Easy to scope the block to picked titles only, or add a grace window, if it proves annoying in use.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GpoULuMzj9a9MJ93wWiqj)_