### PR TITLE
Add a GitHub button to the cleaned-text pane

### DIFF
--- a/src/app/creative/text-cleaner/page.tsx
+++ b/src/app/creative/text-cleaner/page.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import NavTabs from '@/components/nav_tabs';
+import { build_issue_url } from '@/lib/github_issue';
 
 interface TextNote {
   id: string;
@@ -202,6 +203,21 @@ export default function TextCleanerPage() {
       set_copy_status('Copy failed');
       setTimeout(() => set_copy_status(null), 2000);
     }
+  };
+
+  // Open GitHub's own new-issue form with the cleaned text prefilled; the issue is
+  // submitted there, so no token or API route is involved.
+  const send_to_github = () => {
+    if (!cleaned.trim()) return;
+    const { url, truncated } = build_issue_url(cleaned);
+    if (truncated) {
+      // Not awaited: window.open has to run inside the click gesture or popup
+      // blockers (mobile Safari especially) swallow it.
+      navigator.clipboard?.writeText(cleaned).catch(() => {});
+      set_copy_status('Too long for a link, full text copied to clipboard');
+      setTimeout(() => set_copy_status(null), 4000);
+    }
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   const clear_all = () => {
@@ -507,6 +523,13 @@ export default function TextCleanerPage() {
                     className="px-3 py-2 sm:py-1 bg-[#333] sm:bg-white/10 hover:bg-amber-400/20 disabled:bg-white/10 disabled:text-gray-500 rounded border border-[#555] sm:border-white/20 text-sm text-gray-300 transition-all"
                   >
                     {loading_action === 'save' ? 'Saving...' : 'Save'}
+                  </button>
+                  <button
+                    onClick={send_to_github}
+                    title="Open a prefilled GitHub issue with this text"
+                    className="px-3 py-2 sm:py-1 bg-[#333] sm:bg-white/10 hover:bg-sky-400/20 rounded border border-[#555] sm:border-white/20 text-sm text-gray-300 transition-all"
+                  >
+                    GitHub
                   </button>
                   <button
                     onClick={() => copy_output(cleaned)}

--- a/src/lib/__tests__/github_issue.test.ts
+++ b/src/lib/__tests__/github_issue.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { build_issue_url, derive_issue_title, ISSUES_REPO } from '../github_issue';
+
+describe('derive_issue_title', () => {
+  it('uses the first sentence', () => {
+    expect(derive_issue_title('Add a dark mode toggle. It should remember the choice.'))
+      .toBe('Add a dark mode toggle');
+  });
+
+  it('uses the first non-empty line when there is no sentence break', () => {
+    expect(derive_issue_title('\n\nFix the nav dropdown\nsecond line here'))
+      .toBe('Fix the nav dropdown');
+  });
+
+  it('stops at the line break even when the sentence continues below', () => {
+    expect(derive_issue_title('Short line\nrest of the sentence.')).toBe('Short line');
+  });
+
+  it('truncates long titles at a word boundary', () => {
+    const title = derive_issue_title('a'.repeat(10) + ' ' + 'word '.repeat(40) + 'end.');
+    expect(title.length).toBeLessThanOrEqual(73);
+    expect(title.endsWith('...')).toBe(true);
+    expect(title).not.toContain('  ');
+  });
+
+  it('truncates mid-word when there is no early word boundary', () => {
+    const title = derive_issue_title('x'.repeat(200));
+    expect(title).toBe('x'.repeat(70) + '...');
+  });
+
+  it('falls back to a placeholder for empty text', () => {
+    expect(derive_issue_title('   \n  ')).toBe('Note from Say What?');
+  });
+});
+
+describe('build_issue_url', () => {
+  it('builds a prefilled new-issue URL for the repo', () => {
+    const { url, truncated } = build_issue_url('Add a dark mode toggle. Remember it.');
+    expect(truncated).toBe(false);
+    expect(url.startsWith(`https://github.com/${ISSUES_REPO}/issues/new?`)).toBe(true);
+
+    const params = new URL(url).searchParams;
+    expect(params.get('title')).toBe('Add a dark mode toggle');
+    expect(params.get('body')).toBe('Add a dark mode toggle. Remember it.');
+  });
+
+  it('escapes characters that would otherwise break the query string', () => {
+    const body = 'Bug: a&b = c #42 100% "quoted"';
+    const params = new URL(build_issue_url(body).url).searchParams;
+    expect(params.get('body')).toBe(body);
+  });
+
+  it('truncates an oversized body and says so', () => {
+    const { url, truncated } = build_issue_url('long story '.repeat(2000));
+    expect(truncated).toBe(true);
+    expect(url.length).toBeLessThanOrEqual(6000);
+    expect(new URL(url).searchParams.get('body')).toContain('...(truncated');
+  });
+
+  it('keeps the URL under the cap even when every character expands when encoded', () => {
+    const { url, truncated } = build_issue_url('日'.repeat(4000));
+    expect(truncated).toBe(true);
+    expect(url.length).toBeLessThanOrEqual(6000);
+  });
+
+  it('accepts a different repo', () => {
+    const { url } = build_issue_url('hello', 'someone/elsewhere');
+    expect(url.startsWith('https://github.com/someone/elsewhere/issues/new?')).toBe(true);
+  });
+});

--- a/src/lib/github_issue.ts
+++ b/src/lib/github_issue.ts
@@ -1,0 +1,65 @@
+/**
+ * Build a prefilled GitHub "new issue" URL from a block of text.
+ *
+ * No API token involved — the button just opens GitHub's own new-issue form with
+ * the title and body filled in, and the author submits it there.
+ */
+
+export const ISSUES_REPO = 'boneshakerbike/onthisday';
+
+/** Longest title GitHub accepts is 256; keep it shorter so it reads as a summary. */
+const MAX_TITLE = 70;
+
+/**
+ * Browsers and GitHub both cap URL length (GitHub answers 414 well before the
+ * browser gives up). Stay comfortably under it and truncate the body instead of
+ * sending a request that fails.
+ */
+const MAX_URL = 6000;
+
+const TRUNCATION_NOTE = '\n\n...(truncated, full text was copied to your clipboard)';
+
+/** First sentence or line, whichever ends sooner, trimmed to a title-ish length. */
+export function derive_issue_title(text: string): string {
+  const first_line = text.trim().split('\n').find(l => l.trim()) ?? '';
+  const sentence_end = first_line.search(/[.!?](\s|$)/);
+  const candidate = (sentence_end === -1 ? first_line : first_line.slice(0, sentence_end)).trim();
+
+  if (!candidate) return 'Note from Say What?';
+  if (candidate.length <= MAX_TITLE) return candidate;
+
+  // Cut at the last word boundary that fits rather than mid-word.
+  const clipped = candidate.slice(0, MAX_TITLE);
+  const last_space = clipped.lastIndexOf(' ');
+  return `${(last_space > 20 ? clipped.slice(0, last_space) : clipped).trimEnd()}...`;
+}
+
+export interface IssueUrl {
+  url: string;
+  /** True when the body had to be shortened to fit the URL. */
+  truncated: boolean;
+}
+
+export function build_issue_url(text: string, repo: string = ISSUES_REPO): IssueUrl {
+  const body = text.trim();
+  const title = derive_issue_title(body);
+  const base = `https://github.com/${repo}/issues/new?title=${encodeURIComponent(title)}&body=`;
+
+  const encoded = encodeURIComponent(body);
+  if (base.length + encoded.length <= MAX_URL) {
+    return { url: base + encoded, truncated: false };
+  }
+
+  // encodeURIComponent can expand a character up to 9 bytes, so shrink the slice
+  // until the encoded form fits rather than guessing a character count.
+  const budget = MAX_URL - base.length - encodeURIComponent(TRUNCATION_NOTE).length;
+  let keep = Math.min(body.length, budget);
+  while (keep > 0 && encodeURIComponent(body.slice(0, keep)).length > budget) {
+    keep = Math.floor(keep * 0.9);
+  }
+
+  return {
+    url: base + encodeURIComponent(body.slice(0, keep).trimEnd() + TRUNCATION_NOTE),
+    truncated: true,
+  };
+}


### PR DESCRIPTION
Closes #218 (partially — see note below).

Adds a **GitHub** button next to Story / Save / Copy on pane 2 of Say What?. It opens GitHub's own new-issue form in a new tab with the title and body prefilled from the cleaned text; you review and hit Submit there.

No PAT, no new env var, no API route — so nothing to configure before this works in production.

- `src/lib/github_issue.ts` — pure helper: derives a title from the first sentence/line (truncated at a word boundary), URL-encodes the body, and keeps the whole URL under 6000 chars so GitHub never answers 414.
- Oversized text is truncated in the URL and the full text is copied to your clipboard instead, with a toast saying so.
- 11 unit tests in `src/lib/__tests__/github_issue.test.ts`.

**Scope note:** #218 also asked for a transform dropdown on pane 2 (3-paragraph story / SOK / custom prompt). Bill dropped that half — pane 2 keeps its existing Story button as-is.

## Test
1. Open the preview's `/creative/text-cleaner`, paste a rough note, hit **Clean**.
2. Click **GitHub** on the cleaned pane.
3. Expected: a new tab on `github.com/boneshakerbike/onthisday/issues/new` with the title set to the first sentence and the body set to the full cleaned text. Nothing is filed until you press Submit.
4. Paste something very long (~20k chars) and repeat: the body in the form is cut off with a "(truncated…)" note, a toast says the full text was copied, and paste confirms the clipboard has all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)